### PR TITLE
Add visiting mode settings

### DIFF
--- a/public/locales/bs/translation.json
+++ b/public/locales/bs/translation.json
@@ -264,6 +264,26 @@
                 "my_tags_placeholder": "",
                 "no_tags_added": ""
             },
+            "visiting_mode": {
+                "title": "",
+                "description": "",
+                "loading": "",
+                "error": "",
+                "options": {
+                    "auto": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "home": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "visiting": {
+                        "label": "",
+                        "description": ""
+                    }
+                }
+            },
             "states": {
                 "title": "",
                 "description": "",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -351,6 +351,26 @@
                 "my_tags_placeholder": "Schlüsselwörter, durch Kommas getrennt",
                 "no_tags_added": "Noch keine Tags hinzugefügt."
             },
+            "visiting_mode": {
+                "title": "Modus",
+                "description": "Zuhause, Besuch oder Auto",
+                "loading": "Modus wird geladen…",
+                "error": "Modus konnte nicht geladen werden.",
+                "options": {
+                    "auto": {
+                        "label": "Auto",
+                        "description": "Grindr wählt den Modus passend zu deinem aktuellen Standort."
+                    },
+                    "home": {
+                        "label": "Zuhause",
+                        "description": "Zeige dein Profil im Zuhause-Modus."
+                    },
+                    "visiting": {
+                        "label": "Besuch",
+                        "description": "Zeige dein Profil im Besuchsmodus."
+                    }
+                }
+            },
             "states": {
                 "title": "Status",
                 "description": "Sichtbare Statistiken und Profilmerkmale",
@@ -953,6 +973,9 @@
             "load_browse_profiles": "Profile konnten nicht geladen werden",
             "load_profile_details": "Profildetails konnten nicht geladen werden",
             "load_profile": "Profil konnte nicht geladen werden",
+            "load_visiting_mode": "Profilmodus konnte nicht geladen werden",
+            "invalid_visiting_mode_response": "Ungültige Antwort für Profilmodus",
+            "save_visiting_mode": "Profilmodus konnte nicht gespeichert werden",
             "save_profile": "Profil konnte nicht gespeichert werden",
             "update_photos": "Profilfotos konnten nicht aktualisiert werden",
             "delete_photos": "Profilfotos konnten nicht gelöscht werden",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -367,6 +367,26 @@
                 "my_tags_placeholder": "Keyword tags, separated by commas",
                 "no_tags_added": "No tags added yet."
             },
+            "visiting_mode": {
+                "title": "Mode",
+                "description": "Home, visiting, or auto",
+                "loading": "Loading mode…",
+                "error": "Could not load mode.",
+                "options": {
+                    "auto": {
+                        "label": "Auto",
+                        "description": "Let Grindr choose the mode for your current location."
+                    },
+                    "home": {
+                        "label": "Home",
+                        "description": "Show your profile in home mode."
+                    },
+                    "visiting": {
+                        "label": "Visiting",
+                        "description": "Show your profile in visiting mode."
+                    }
+                }
+            },
             "states": {
                 "title": "States",
                 "description": "Visible stats and profile traits",
@@ -1001,6 +1021,9 @@
             "load_browse_profiles": "Failed to load browse profiles",
             "load_profile_details": "Failed to load profile details",
             "load_profile": "Failed to load profile",
+            "load_visiting_mode": "Failed to load profile mode",
+            "invalid_visiting_mode_response": "Invalid profile mode response",
+            "save_visiting_mode": "Failed to save profile mode",
             "save_profile": "Failed to save profile",
             "update_photos": "Failed to update profile photos",
             "delete_photos": "Failed to delete profile photos",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -272,6 +272,26 @@
                 "my_tags_placeholder": "Etiquetas clave, separadas por comas",
                 "no_tags_added": "No se han añadido etiquetas todavía."
             },
+            "visiting_mode": {
+                "title": "Modo",
+                "description": "Casa, visita o automático",
+                "loading": "Cargando modo…",
+                "error": "No se pudo cargar el modo.",
+                "options": {
+                    "auto": {
+                        "label": "Auto",
+                        "description": "Deja que Grindr elija el modo para tu ubicación actual."
+                    },
+                    "home": {
+                        "label": "Casa",
+                        "description": "Muestra tu perfil en modo casa."
+                    },
+                    "visiting": {
+                        "label": "Visita",
+                        "description": "Muestra tu perfil en modo visita."
+                    }
+                }
+            },
             "states": {
                 "title": "Estados",
                 "description": "Estadísticas visibles y rasgos del perfil",
@@ -943,6 +963,9 @@
             "load_browse_profiles": "Error al cargar perfiles de navegar",
             "load_profile_details": "Error al cargar detalles de perfil",
             "load_profile": "Error al cargar perfil",
+            "load_visiting_mode": "Error al cargar modo de perfil",
+            "invalid_visiting_mode_response": "Respuesta inválida de modo de perfil",
+            "save_visiting_mode": "Error al guardar modo de perfil",
             "save_profile": "Error al guardar perfil",
             "update_photos": "Error al actualizar fotos del perfil",
             "delete_photos": "Error al borrar fotos de perfil",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -271,6 +271,26 @@
                 "my_tags_placeholder": "Mots-clés, séparés par des virgules",
                 "no_tags_added": "Aucun tag ajouté pour le moment."
             },
+            "visiting_mode": {
+                "title": "",
+                "description": "",
+                "loading": "",
+                "error": "",
+                "options": {
+                    "auto": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "home": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "visiting": {
+                        "label": "",
+                        "description": ""
+                    }
+                }
+            },
             "states": {
                 "title": "Statistiques",
                 "description": "Statistiques visibles et traits du profil",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -259,6 +259,26 @@
                 "my_tags_placeholder": "",
                 "no_tags_added": ""
             },
+            "visiting_mode": {
+                "title": "",
+                "description": "",
+                "loading": "",
+                "error": "",
+                "options": {
+                    "auto": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "home": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "visiting": {
+                        "label": "",
+                        "description": ""
+                    }
+                }
+            },
             "states": {
                 "title": "",
                 "description": "",

--- a/public/locales/sl/translation.json
+++ b/public/locales/sl/translation.json
@@ -269,6 +269,26 @@
                 "my_tags_placeholder": "",
                 "no_tags_added": ""
             },
+            "visiting_mode": {
+                "title": "",
+                "description": "",
+                "loading": "",
+                "error": "",
+                "options": {
+                    "auto": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "home": {
+                        "label": "",
+                        "description": ""
+                    },
+                    "visiting": {
+                        "label": "",
+                        "description": ""
+                    }
+                }
+            },
             "states": {
                 "title": "",
                 "description": "",

--- a/src/pages/app/ProfileEditorPage.tsx
+++ b/src/pages/app/ProfileEditorPage.tsx
@@ -9,6 +9,10 @@ import { useNavigate } from "react-router-dom";
 import z from "zod";
 import { useAuth } from "../../contexts/useAuth";
 import { useApiFunctions } from "../../hooks/useApiFunctions";
+import {
+	getVisitingModeTranslationKey,
+	type VisitingMode,
+} from "../../types/visiting";
 import { validateMediaHash } from "../../utils/media";
 import { BackToSettings } from "../../components/BackToSettings";
 import {
@@ -52,6 +56,12 @@ export function ProfileEditorPage() {
 	const [isLoadingProfile, setIsLoadingProfile] = useState(true);
 	const [profileError, setProfileError] = useState<string | null>(null);
 	const [draft, setDraft] = useState<ProfileDraft>(emptyDraft);
+	const [savedVisitingMode, setSavedVisitingMode] =
+		useState<VisitingMode>("AUTO");
+	const [draftVisitingMode, setDraftVisitingMode] =
+		useState<VisitingMode>("AUTO");
+	const [isLoadingVisitingMode, setIsLoadingVisitingMode] = useState(false);
+	const [visitingModeError, setVisitingModeError] = useState<string | null>(null);
 	const [isSaving, setIsSaving] = useState(false);
 	const [isSavingPhotos, setIsSavingPhotos] = useState(false);
 	const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
@@ -151,6 +161,30 @@ export function ProfileEditorPage() {
 		}
 	}, [apiFunctions, userId, t]);
 
+	const loadVisitingMode = useCallback(async () => {
+		if (!userId) {
+			setSavedVisitingMode("AUTO");
+			setDraftVisitingMode("AUTO");
+			setIsLoadingVisitingMode(false);
+			setVisitingModeError(null);
+			return;
+		}
+
+		try {
+			setIsLoadingVisitingMode(true);
+			setVisitingModeError(null);
+			setSavedVisitingMode(await apiFunctions.getVisitingMode());
+		} catch (error) {
+			setVisitingModeError(
+				error instanceof Error
+					? error.message
+					: t("profile_editor.sections.visiting_mode.error"),
+			);
+		} finally {
+			setIsLoadingVisitingMode(false);
+		}
+	}, [apiFunctions, userId, t]);
+
 	const loadManagedOptions = useCallback(async () => {
 		try {
 			const genders = await apiFunctions.getManagedGenders();
@@ -178,11 +212,16 @@ export function ProfileEditorPage() {
 	useEffect(() => {
 		void loadProfile();
 		void loadManagedOptions();
-	}, [loadManagedOptions, loadProfile]);
+		void loadVisitingMode();
+	}, [loadManagedOptions, loadProfile, loadVisitingMode]);
 
 	useEffect(() => {
 		setDraft(profileToDraft(profile));
 	}, [profile]);
+
+	useEffect(() => {
+		setDraftVisitingMode(savedVisitingMode);
+	}, [savedVisitingMode]);
 
 	const displayName = useMemo(() => {
 		if (profile?.displayName?.trim()) {
@@ -203,10 +242,13 @@ export function ProfileEditorPage() {
 
 	const savedDraft = useMemo(() => profileToDraft(profile), [profile]);
 
-	const hasChanges = useMemo(
+	const hasProfileChanges = useMemo(
 		() => JSON.stringify(draft) !== JSON.stringify(savedDraft),
 		[draft, savedDraft],
 	);
+
+	const hasVisitingModeChanges = draftVisitingMode !== savedVisitingMode;
+	const hasChanges = hasProfileChanges || hasVisitingModeChanges;
 
 	const tagList = useMemo(
 		() => normalizeTagList(draft.profileTagsText),
@@ -258,6 +300,11 @@ export function ProfileEditorPage() {
 
 		return bodyTypeLabels[Number(draft.bodyType)] ?? `Type ${draft.bodyType}`;
 	}, [draft.bodyType, bodyTypeLabels, t]);
+
+	const selectedVisitingModeLabel = useMemo(() => {
+		const modeKey = getVisitingModeTranslationKey(draftVisitingMode);
+		return t(`profile_editor.sections.visiting_mode.options.${modeKey}.label`);
+	}, [draftVisitingMode, t]);
 
 	const completionChecklist = useMemo(
 		() => [
@@ -351,39 +398,48 @@ export function ProfileEditorPage() {
 		setIsSaving(true);
 
 		try {
-			await apiFunctions.updateMyProfile({
-				displayName: draft.displayName.trim() || null,
-				aboutMe: draft.aboutMe.trim() || null,
-				profileTags: tagList,
-				showAge: draft.showAge,
-				age: parseNullableInteger(draft.age),
-				height: parseNullableNumber(draft.height),
-				weight: parseNullableNumber(draft.weight),
-				ethnicity: parseNullableInteger(draft.ethnicity),
-				bodyType: parseNullableInteger(draft.bodyType),
-				showPosition: draft.showPosition,
-				sexualPosition: parseNullableInteger(draft.sexualPosition),
-				showTribes: draft.showTribes,
-				grindrTribes: draft.grindrTribes,
-				relationshipStatus: parseNullableInteger(draft.relationshipStatus),
-				lookingFor: draft.lookingFor,
-				meetAt: draft.meetAt,
-				nsfw: parseNullableInteger(draft.nsfw),
-				genders: draft.genders,
-				pronouns: draft.pronouns,
-				hivStatus: parseNullableInteger(draft.hivStatus),
-				lastTestedDate: parseDateInput(draft.lastTestedDate),
-				sexualHealth: draft.sexualHealth,
-				vaccines: draft.vaccines,
-				socialNetworks: {
-					instagram: { userId: draft.instagram.trim() || null },
-					twitter: { userId: draft.twitter.trim() || null },
-					facebook: { userId: draft.facebook.trim() || null },
-				},
-			});
+			if (hasProfileChanges) {
+				await apiFunctions.updateMyProfile({
+					displayName: draft.displayName.trim() || null,
+					aboutMe: draft.aboutMe.trim() || null,
+					profileTags: tagList,
+					showAge: draft.showAge,
+					age: parseNullableInteger(draft.age),
+					height: parseNullableNumber(draft.height),
+					weight: parseNullableNumber(draft.weight),
+					ethnicity: parseNullableInteger(draft.ethnicity),
+					bodyType: parseNullableInteger(draft.bodyType),
+					showPosition: draft.showPosition,
+					sexualPosition: parseNullableInteger(draft.sexualPosition),
+					showTribes: draft.showTribes,
+					grindrTribes: draft.grindrTribes,
+					relationshipStatus: parseNullableInteger(draft.relationshipStatus),
+					lookingFor: draft.lookingFor,
+					meetAt: draft.meetAt,
+					nsfw: parseNullableInteger(draft.nsfw),
+					genders: draft.genders,
+					pronouns: draft.pronouns,
+					hivStatus: parseNullableInteger(draft.hivStatus),
+					lastTestedDate: parseDateInput(draft.lastTestedDate),
+					sexualHealth: draft.sexualHealth,
+					vaccines: draft.vaccines,
+					socialNetworks: {
+						instagram: { userId: draft.instagram.trim() || null },
+						twitter: { userId: draft.twitter.trim() || null },
+						facebook: { userId: draft.facebook.trim() || null },
+					},
+				});
+			}
+
+			if (hasVisitingModeChanges) {
+				await apiFunctions.updateVisitingMode(draftVisitingMode);
+				setSavedVisitingMode(draftVisitingMode);
+			}
 
 			toast.success(t("profile_editor.toasts.updated"));
-			await loadProfile();
+			if (hasProfileChanges) {
+				await loadProfile();
+			}
 		} catch (error) {
 			const message =
 				error instanceof Error
@@ -563,6 +619,7 @@ export function ProfileEditorPage() {
 
 	const handleResetDraft = () => {
 		setDraft(savedDraft);
+		setDraftVisitingMode(savedVisitingMode);
 	};
 
 	const handleLogout = async () => {
@@ -635,6 +692,9 @@ export function ProfileEditorPage() {
 														})
 													: t("profile_editor.no_tags")}
 											</span>
+											<span className="rounded-full border border-[var(--border)] bg-[var(--surface-2)] px-3 py-1 text-sm font-medium text-[var(--text-muted)]">
+												{selectedVisitingModeLabel}
+											</span>
 										</div>
 									</div>
 								</div>
@@ -677,6 +737,10 @@ export function ProfileEditorPage() {
 								onUploadPhoto={handleUploadPhoto}
 								onSetPrimaryPhoto={handleSetPrimaryPhoto}
 								onRemovePhoto={handleRemovePhoto}
+								visitingMode={draftVisitingMode}
+								isLoadingVisitingMode={isLoadingVisitingMode}
+								visitingModeError={visitingModeError}
+								onVisitingModeChange={setDraftVisitingMode}
 								profileId={profile?.profileId ?? userId}
 								ethnicityOptions={ethnicityOptions}
 								bodyTypeOptions={bodyTypeOptions}

--- a/src/pages/app/profile-editor/ProfileEditorFormSections.tsx
+++ b/src/pages/app/profile-editor/ProfileEditorFormSections.tsx
@@ -4,13 +4,20 @@ import {
 	AtSign,
 	BadgeInfo,
 	Camera,
+	Compass,
+	Home,
 	ImageOff,
+	MapPin,
 	Ruler,
 	ShieldPlus,
 	Sparkles,
 	Star,
 	Trash2,
 } from "lucide-react";
+import {
+	getVisitingModeTranslationKey,
+	type VisitingMode,
+} from "../../../types/visiting";
 import { getThumbImageUrl } from "../../../utils/media";
 import { CategoryHeader, ChipGroup, ToggleRow } from "./ProfileEditorComponents";
 import { MAX_PROFILE_PHOTOS, type ProfileDraft } from "./profileEditorUtils";
@@ -40,6 +47,10 @@ type ProfileEditorFormSectionsProps = {
 	onUploadPhoto: (event: React.ChangeEvent<HTMLInputElement>) => void;
 	onSetPrimaryPhoto: (hash: string) => void;
 	onRemovePhoto: (hash: string) => void;
+	visitingMode: VisitingMode;
+	isLoadingVisitingMode: boolean;
+	visitingModeError: string | null;
+	onVisitingModeChange: (value: VisitingMode) => void;
 	profileId?: string | number | null;
 	ethnicityOptions: Option[];
 	bodyTypeOptions: Option[];
@@ -70,6 +81,10 @@ export function ProfileEditorFormSections({
 	onUploadPhoto,
 	onSetPrimaryPhoto,
 	onRemovePhoto,
+	visitingMode,
+	isLoadingVisitingMode,
+	visitingModeError,
+	onVisitingModeChange,
 	profileId,
 	ethnicityOptions,
 	bodyTypeOptions,
@@ -86,6 +101,15 @@ export function ProfileEditorFormSections({
 	vaccineOptions,
 }: ProfileEditorFormSectionsProps) {
 	const { t } = useTranslation();
+	const visitingModeDisabled = isLoadingVisitingMode || Boolean(visitingModeError);
+	const visitingModeOptions: Array<{
+		value: VisitingMode;
+		icon: typeof MapPin;
+	}> = [
+		{ value: "AUTO", icon: Compass },
+		{ value: "OFF", icon: Home },
+		{ value: "ON", icon: MapPin },
+	];
 
 	return (
 		<div className="grid gap-5">
@@ -280,6 +304,78 @@ export function ProfileEditorFormSections({
 						</div>
 					</div>
 				</div>
+			</div>
+
+			{/* Visiting Mode */}
+			<div className="surface-card rounded-3xl p-4 sm:p-5">
+				<CategoryHeader
+					title={t("profile_editor.sections.visiting_mode.title")}
+					description={t("profile_editor.sections.visiting_mode.description")}
+					icon={MapPin}
+				/>
+				<div
+					role="radiogroup"
+					aria-label={t("profile_editor.sections.visiting_mode.title")}
+					className="grid gap-2 sm:grid-cols-3"
+				>
+					{visitingModeOptions.map((option) => {
+						const active = option.value === visitingMode;
+						const Icon = option.icon;
+						const modeKey = getVisitingModeTranslationKey(option.value);
+
+						return (
+							<button
+								key={option.value}
+								type="button"
+								role="radio"
+								aria-checked={active}
+								disabled={visitingModeDisabled}
+								onClick={() => onVisitingModeChange(option.value)}
+								className={`flex min-h-32 flex-col items-start gap-3 rounded-2xl border px-4 py-3.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60 ${
+									active
+										? "border-transparent bg-[var(--accent)] text-[var(--accent-contrast)]"
+										: "border-[var(--border)] bg-[var(--surface-2)] hover:border-[var(--text-muted)]"
+								}`}
+							>
+								<span
+									className={`rounded-xl border p-2 ${
+										active
+											? "border-[var(--accent-contrast)]/30 bg-[var(--accent-contrast)]/15"
+											: "border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)]"
+									}`}
+								>
+									<Icon className="h-4 w-4" strokeWidth={2.1} />
+								</span>
+								<span className="text-sm font-semibold">
+									{t(
+										`profile_editor.sections.visiting_mode.options.${modeKey}.label`,
+									)}
+								</span>
+								<span
+									className={`text-xs leading-relaxed ${
+										active
+											? "text-[var(--accent-contrast)]/80"
+											: "text-[var(--text-muted)]"
+									}`}
+								>
+									{t(
+										`profile_editor.sections.visiting_mode.options.${modeKey}.description`,
+									)}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+				{isLoadingVisitingMode || visitingModeError ? (
+					<p
+						className={`mt-3 text-xs leading-relaxed ${
+							visitingModeError ? "text-red-300" : "text-[var(--text-muted)]"
+						}`}
+					>
+						{visitingModeError ??
+							t("profile_editor.sections.visiting_mode.loading")}
+					</p>
+				) : null}
 			</div>
 
 			{/* Stats / States */}

--- a/src/services/api/profileMethods.ts
+++ b/src/services/api/profileMethods.ts
@@ -12,6 +12,8 @@ import type {
 	ProfileImageUploadResult,
 } from "../../types/api-functions";
 import type { RestFetcher } from "../../types/chat-service";
+import type { VisitingMode } from "../../types/visiting";
+import { isVisitingMode } from "../../types/visiting";
 import { ApiFunctionError, assertSuccess, parseJsonSafe } from "../apiHelpers";
 
 export function createProfileMethods(fetchRest: RestFetcher, t: (key: string) => string) {
@@ -243,6 +245,35 @@ export function createProfileMethods(fetchRest: RestFetcher, t: (key: string) =>
 			const response = await fetchRest(`/v7/profiles/${profileId}`);
 			await assertSuccess(response, t("api.errors.load_profile"));
 			return parseJsonSafe(response);
+		},
+
+		async getVisitingMode(): Promise<VisitingMode> {
+			const response = await fetchRest("/v1/visiting/settings");
+			await assertSuccess(response, t("api.errors.load_visiting_mode"));
+			const payload = await parseJsonSafe(response);
+			const setting =
+				typeof payload === "object" && payload !== null
+					? (payload as { setting?: unknown }).setting
+					: null;
+
+			if (!isVisitingMode(setting)) {
+				throw new ApiFunctionError(
+					t("api.errors.invalid_visiting_mode_response"),
+					response.status,
+					payload,
+				);
+			}
+
+			return setting;
+		},
+
+		async updateVisitingMode(setting: VisitingMode): Promise<{ ok: true }> {
+			const response = await fetchRest("/v1/visiting/settings", {
+				method: "PUT",
+				body: { setting },
+			});
+			await assertSuccess(response, t("api.errors.save_visiting_mode"));
+			return { ok: true };
 		},
 
 		async updateMyProfile(payload: unknown): Promise<{ ok: true }> {

--- a/src/types/visiting.ts
+++ b/src/types/visiting.ts
@@ -1,0 +1,22 @@
+export const VISITING_MODES = ["AUTO", "OFF", "ON"] as const;
+
+export type VisitingMode = (typeof VISITING_MODES)[number];
+
+const VISITING_MODE_TRANSLATION_KEYS: Record<
+	VisitingMode,
+	"auto" | "home" | "visiting"
+> = {
+	AUTO: "auto",
+	OFF: "home",
+	ON: "visiting",
+};
+
+export function isVisitingMode(value: unknown): value is VisitingMode {
+	return (
+		typeof value === "string" && VISITING_MODES.includes(value as VisitingMode)
+	);
+}
+
+export function getVisitingModeTranslationKey(mode: VisitingMode) {
+	return VISITING_MODE_TRANSLATION_KEYS[mode];
+}


### PR DESCRIPTION
## Summary
- Add profile mode controls to the profile editor.
- Wire profile mode and visiting mode fields into the profile update request.
- Add shared visiting-mode types and localized profile-mode labels.

## Why
This adds the settings surface needed to control profile mode behavior from the app and send the corresponding Grindr payload fields.

## Validation
- Validated in test build.