### PR TITLE
Chat UX improvements part 2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "react-dom": "^19",
         "react-hot-toast": "^2.4.1",
         "react-i18next": "^17.0.6",
+        "react-image-crop": "^11.0.10",
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^7",
         "tailwindcss": "^4.2.2",
@@ -772,6 +773,8 @@
     "react-hot-toast": ["react-hot-toast@2.6.0", "", { "dependencies": { "csstype": "^3.1.3", "goober": "^2.1.16" }, "peerDependencies": { "react": ">=16", "react-dom": ">=16" } }, "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg=="],
 
     "react-i18next": ["react-i18next@17.0.6", "", { "dependencies": { "@babel/runtime": "^7.29.2", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 26.0.1", "react": ">= 16.8.0", "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw=="],
+
+    "react-image-crop": ["react-image-crop@11.0.10", "", { "peerDependencies": { "react": ">=16.13.1" } }, "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ=="],
 
     "react-leaflet": ["react-leaflet@4.2.1", "", { "dependencies": { "@react-leaflet/core": "^2.1.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "react-dom": "^19",
         "react-hot-toast": "^2.4.1",
         "react-i18next": "^17.0.6",
+        "react-image-crop": "^11.0.10",
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^7",
         "tailwindcss": "^4.2.2",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -788,7 +788,8 @@
             "only_image_video": "Only image and video attachments are supported.",
             "ready_to_send": "Ready to send: {{file}}",
             "looping": "looping",
-            "taken_on_grindr": "takenOnGrindr",
+            "taken_on_grindr": "Taken on Grindr watermark",
+            "taken_on_grindr_description": "Include the timestamp to certify the authenticy and recency of your photo",
             "send_attachment": "Send attachment",
             "uploading": "Uploading attachment",
             "too_large": "Attachment is too large. Limit is 12MB."

--- a/src/components/BackToSettings.tsx
+++ b/src/components/BackToSettings.tsx
@@ -7,7 +7,7 @@ export function BackToSettings() {
 		<button
 			type="button"
 			onClick={() => navigate("/settings")}
-			className="mb-4 flex items-center gap-1.5 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
+			className="flex items-center gap-1.5 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
 		>
 			<ChevronLeft className="h-4 w-4" />
 			Settings

--- a/src/components/PhotoViewer.tsx
+++ b/src/components/PhotoViewer.tsx
@@ -240,7 +240,7 @@ export function PhotoViewer({
 				)}
 
 				{renderExtraInfo && (
-					<div className="flex items-center gap-2">
+					<div className="absolute bottom-3 left-3 flex items-center gap-2">
 						{renderExtraInfo(safeIndex)}
 					</div>
 				)}

--- a/src/components/PhotoViewer.tsx
+++ b/src/components/PhotoViewer.tsx
@@ -243,8 +243,6 @@ export function PhotoViewer({
 						{safeIndex + 1} / {photos.length}
 					</p>
 				)}
-
-				
 			</div>
 		</div>
 	);

--- a/src/components/PhotoViewer.tsx
+++ b/src/components/PhotoViewer.tsx
@@ -230,6 +230,11 @@ export function PhotoViewer({
 								}}
 							/>
 						)}
+                        {renderExtraInfo && (
+                            <div className="absolute bottom-3 left-3 flex items-center gap-2">
+                                {renderExtraInfo(safeIndex)}
+                            </div>
+                        )}
 					</div>
 				</div>
 
@@ -239,11 +244,7 @@ export function PhotoViewer({
 					</p>
 				)}
 
-				{renderExtraInfo && (
-					<div className="absolute bottom-3 left-3 flex items-center gap-2">
-						{renderExtraInfo(safeIndex)}
-					</div>
-				)}
+				
 			</div>
 		</div>
 	);

--- a/src/components/ui/bottom-drawer.tsx
+++ b/src/components/ui/bottom-drawer.tsx
@@ -1,5 +1,6 @@
 import { Loader2, X } from "lucide-react";
 import type { ReactNode } from "react";
+import { BottomSheet } from "./bottom-sheet";
 
 interface BottomDrawerProps {
 	title: string;
@@ -25,52 +26,46 @@ export function BottomDrawer({
 	children,
 }: BottomDrawerProps) {
 	return (
-		<div
-			className={`fixed inset-0 ${zIndex} flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout`}
-			onClick={isProcessing ? undefined : onClose}
+		<BottomSheet
+			onClose={onClose}
+			isDesktop={isDesktop}
+			isProcessing={isProcessing}
+			zIndex={zIndex}
 		>
-			<div
-				className={`flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"}`}
-				onClick={(e) => e.stopPropagation()}
-			>
-				<div className="flex items-center justify-between px-4 py-3">
-					<p className="text-sm font-semibold text-[var(--text)]">{title}</p>
-					<button
-						type="button"
-						onClick={onClose}
-						disabled={isProcessing}
-						className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
-					>
-						<X className="h-4 w-4" />
-					</button>
-				</div>
-				{children}
-				<div
-					className="flex gap-2 px-3 pb-3"
-					style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}
+			<div className="flex items-center justify-between px-4 pb-3">
+				<p className="text-sm font-semibold text-[var(--text)]">{title}</p>
+				<button
+					type="button"
+					onClick={onClose}
+					disabled={isProcessing}
+					className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
 				>
-					<button
-						type="button"
-						onClick={onClose}
-						disabled={isProcessing}
-						className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-					>
-						{cancelLabel}
-					</button>
-					<button
-						type="button"
-						onClick={onConfirm}
-						disabled={isProcessing}
-						className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-					>
-						{isProcessing ? (
-							<Loader2 className="mx-auto h-4 w-4 animate-spin" />
-						) : (
-							confirmLabel
-						)}
-					</button>
-				</div>
+					<X className="h-4 w-4" />
+				</button>
 			</div>
-		</div>
+			{children}
+			<div className="flex gap-2 px-3">
+				<button
+					type="button"
+					onClick={onClose}
+					disabled={isProcessing}
+					className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+				>
+					{cancelLabel}
+				</button>
+				<button
+					type="button"
+					onClick={onConfirm}
+					disabled={isProcessing}
+					className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+				>
+					{isProcessing ? (
+						<Loader2 className="mx-auto h-4 w-4 animate-spin" />
+					) : (
+						confirmLabel
+					)}
+				</button>
+			</div>
+		</BottomSheet>
 	);
 }

--- a/src/components/ui/bottom-drawer.tsx
+++ b/src/components/ui/bottom-drawer.tsx
@@ -7,7 +7,7 @@ interface BottomDrawerProps {
 	onClose: () => void;
 	onConfirm: () => void;
 	confirmLabel: string;
-	cancelLabel: string;
+	cancelLabel?: string;
 	isProcessing?: boolean;
 	zIndex?: string;
 	isDesktop?: boolean;
@@ -43,12 +43,14 @@ export function BottomDrawer({
 			</div>
 			{children}
 			<div className="flex gap-2 px-3">
-				<SheetClose
-					disabled={isProcessing}
-					className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-				>
-					{cancelLabel}
-				</SheetClose>
+				{cancelLabel && (
+					<SheetClose
+						disabled={isProcessing}
+						className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+					>
+						{cancelLabel}
+					</SheetClose>
+				)}
 				<button
 					type="button"
 					onClick={onConfirm}

--- a/src/components/ui/bottom-drawer.tsx
+++ b/src/components/ui/bottom-drawer.tsx
@@ -1,6 +1,6 @@
 import { Loader2, X } from "lucide-react";
 import type { ReactNode } from "react";
-import { BottomSheet } from "./bottom-sheet";
+import { BottomSheet, SheetClose } from "./bottom-sheet";
 
 interface BottomDrawerProps {
 	title: string;
@@ -34,25 +34,21 @@ export function BottomDrawer({
 		>
 			<div className="flex items-center justify-between px-4 pb-3">
 				<p className="text-sm font-semibold text-[var(--text)]">{title}</p>
-				<button
-					type="button"
-					onClick={onClose}
+				<SheetClose
 					disabled={isProcessing}
 					className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
 				>
 					<X className="h-4 w-4" />
-				</button>
+				</SheetClose>
 			</div>
 			{children}
 			<div className="flex gap-2 px-3">
-				<button
-					type="button"
-					onClick={onClose}
+				<SheetClose
 					disabled={isProcessing}
 					className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
 				>
 					{cancelLabel}
-				</button>
+				</SheetClose>
 				<button
 					type="button"
 					onClick={onConfirm}

--- a/src/components/ui/bottom-drawer.tsx
+++ b/src/components/ui/bottom-drawer.tsx
@@ -1,0 +1,74 @@
+import { Loader2, X } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface BottomDrawerProps {
+	title: string;
+	onClose: () => void;
+	onConfirm: () => void;
+	confirmLabel: string;
+	cancelLabel: string;
+	isProcessing?: boolean;
+	zIndex?: string;
+	children: ReactNode;
+}
+
+export function BottomDrawer({
+	title,
+	onClose,
+	onConfirm,
+	confirmLabel,
+	cancelLabel,
+	isProcessing = false,
+	zIndex = "z-40",
+	children,
+}: BottomDrawerProps) {
+	return (
+		<div
+			className={`fixed inset-0 ${zIndex} flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout`}
+			onClick={isProcessing ? undefined : onClose}
+		>
+			<div
+				className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden mx-3"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<div className="flex items-center justify-between px-4 py-3">
+					<p className="text-sm font-semibold text-[var(--text)]">{title}</p>
+					<button
+						type="button"
+						onClick={onClose}
+						disabled={isProcessing}
+						className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
+				{children}
+				<div
+					className="flex gap-2 px-3 pb-3"
+					style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}
+				>
+					<button
+						type="button"
+						onClick={onClose}
+						disabled={isProcessing}
+						className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+					>
+						{cancelLabel}
+					</button>
+					<button
+						type="button"
+						onClick={onConfirm}
+						disabled={isProcessing}
+						className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+					>
+						{isProcessing ? (
+							<Loader2 className="mx-auto h-4 w-4 animate-spin" />
+						) : (
+							confirmLabel
+						)}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ui/bottom-drawer.tsx
+++ b/src/components/ui/bottom-drawer.tsx
@@ -9,6 +9,7 @@ interface BottomDrawerProps {
 	cancelLabel: string;
 	isProcessing?: boolean;
 	zIndex?: string;
+	isDesktop?: boolean;
 	children: ReactNode;
 }
 
@@ -19,7 +20,8 @@ export function BottomDrawer({
 	confirmLabel,
 	cancelLabel,
 	isProcessing = false,
-	zIndex = "z-40",
+	zIndex = "z-[60]",
+	isDesktop = false,
 	children,
 }: BottomDrawerProps) {
 	return (
@@ -28,7 +30,7 @@ export function BottomDrawer({
 			onClick={isProcessing ? undefined : onClose}
 		>
 			<div
-				className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden mx-3"
+				className={`flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"}`}
 				onClick={(e) => e.stopPropagation()}
 			>
 				<div className="flex items-center justify-between px-4 py-3">

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,81 @@
+import { useRef, useState, type ReactNode } from "react";
+
+interface BottomSheetProps {
+	onClose: () => void;
+	onExpand?: () => void;
+	isDesktop?: boolean;
+	isProcessing?: boolean;
+	zIndex?: string;
+	bg?: string;
+	panelClassName?: string;
+	children: ReactNode;
+}
+
+export function BottomSheet({
+	onClose,
+	onExpand,
+	isDesktop = false,
+	isProcessing = false,
+	zIndex = "z-[60]",
+	bg = "bg-[var(--surface)]",
+	panelClassName = "",
+	children,
+}: BottomSheetProps) {
+	const [dragY, setDragY] = useState(0);
+	const [isDragging, setIsDragging] = useState(false);
+	const dragStartY = useRef<number | null>(null);
+
+	const onTouchStart = (e: React.TouchEvent) => {
+		dragStartY.current = e.touches[0].clientY;
+		setIsDragging(true);
+	};
+
+	const onTouchMove = (e: React.TouchEvent) => {
+		if (dragStartY.current === null) return;
+		const delta = e.touches[0].clientY - dragStartY.current;
+		if (delta < -60 && onExpand) {
+			onExpand();
+			dragStartY.current = e.touches[0].clientY;
+			return;
+		}
+		setDragY(Math.max(0, delta));
+	};
+
+	const onTouchEnd = () => {
+		if (dragY > 100 && !isProcessing) onClose();
+		setDragY(0);
+		setIsDragging(false);
+		dragStartY.current = null;
+	};
+
+	return (
+		<div
+			className={`fixed inset-0 ${zIndex} flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout`}
+			onClick={isProcessing ? undefined : onClose}
+		>
+			<div
+				className={`flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] ${bg} shadow-2xl overflow-hidden ${isDesktop ? "max-w-[800px] mx-auto" : "mx-3"} ${panelClassName}`}
+				style={{
+					transform: `translateY(${dragY}px)`,
+					transition: isDragging ? "none" : "transform 0.25s ease",
+					willChange: "transform",
+					paddingBottom: "max(16px, env(safe-area-inset-bottom))",
+				}}
+				onClick={(e) => e.stopPropagation()}
+			>
+				{!isDesktop && (
+					<div
+						className="flex justify-center pt-2.5 pb-1 cursor-grab touch-none"
+						onTouchStart={onTouchStart}
+						onTouchMove={onTouchMove}
+						onTouchEnd={onTouchEnd}
+					>
+						<div className="h-1 w-10 rounded-full bg-[var(--border)]" />
+					</div>
+				)}
+				{isDesktop && <div className="pt-4" />}
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -1,4 +1,28 @@
-import { useRef, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+
+const BottomSheetContext = createContext<() => void>(() => {});
+export const useBottomSheetClose = () => useContext(BottomSheetContext);
+
+interface SheetCloseProps {
+	children: ReactNode;
+	className?: string;
+	disabled?: boolean;
+	onClick?: () => void;
+}
+
+export function SheetClose({ children, className, disabled, onClick }: SheetCloseProps) {
+	const close = useBottomSheetClose();
+	return (
+		<button
+			type="button"
+			disabled={disabled}
+			className={className}
+			onClick={() => { onClick?.(); close(); }}
+		>
+			{children}
+		</button>
+	);
+}
 
 interface BottomSheetProps {
 	onClose: () => void;
@@ -23,7 +47,61 @@ export function BottomSheet({
 }: BottomSheetProps) {
 	const [dragY, setDragY] = useState(0);
 	const [isDragging, setIsDragging] = useState(false);
+	const [isVisible, setIsVisible] = useState(false);
+	const [isClosing, setIsClosing] = useState(false);
 	const dragStartY = useRef<number | null>(null);
+	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const closingRef = useRef(false);
+	const closedByBackRef = useRef(false);
+	const animateCloseRef = useRef<() => void>(() => {});
+
+	// useEffect fires after browser has painted — double RAF ensures initial
+	// translateY(120%) is committed before we transition to translateY(0)
+	useEffect(() => {
+		let r1: number, r2: number;
+		r1 = requestAnimationFrame(() => {
+			r2 = requestAnimationFrame(() => setIsVisible(true));
+		});
+		return () => {
+			cancelAnimationFrame(r1);
+			cancelAnimationFrame(r2);
+			if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+		};
+	}, []);
+
+	const animateClose = useCallback(() => {
+		if (isProcessing || closingRef.current) return;
+		closingRef.current = true;
+		setIsClosing(true);
+		closeTimerRef.current = setTimeout(onClose, 320);
+	}, [isProcessing, onClose]);
+
+	useEffect(() => { animateCloseRef.current = animateClose; }, [animateClose]);
+
+	useEffect(() => {
+		const prevState = history.state;
+		history.pushState({ bottomSheet: true }, "");
+		const onPopState = () => {
+			closedByBackRef.current = true;
+			animateCloseRef.current();
+		};
+		window.addEventListener("popstate", onPopState);
+		return () => {
+			window.removeEventListener("popstate", onPopState);
+			if (!closedByBackRef.current) history.replaceState(prevState, "");
+		};
+	}, []);
+
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && !isProcessing) {
+				e.stopImmediatePropagation();
+				animateClose();
+			}
+		};
+		window.addEventListener("keydown", onKeyDown, { capture: true });
+		return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+	}, [isProcessing, animateClose]);
 
 	const onTouchStart = (e: React.TouchEvent) => {
 		dragStartY.current = e.touches[0].clientY;
@@ -42,40 +120,51 @@ export function BottomSheet({
 	};
 
 	const onTouchEnd = () => {
-		if (dragY > 100 && !isProcessing) onClose();
+		if (dragY > 100) animateClose();
 		setDragY(0);
 		setIsDragging(false);
 		dragStartY.current = null;
 	};
 
+	const isAnimating = isVisible && !isDragging;
+	const transform = (!isVisible || isClosing)
+		? "translateY(120%)"
+		: `translateY(${dragY}px)`;
+
 	return (
-		<div
-			className={`fixed inset-0 ${zIndex} flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout`}
-			onClick={isProcessing ? undefined : onClose}
-		>
+		<BottomSheetContext.Provider value={animateClose}>
 			<div
-				className={`flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] ${bg} shadow-2xl overflow-hidden ${isDesktop ? "max-w-[800px] mx-auto" : "mx-3"} ${panelClassName}`}
+				className={`fixed inset-0 ${zIndex} flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout`}
 				style={{
-					transform: `translateY(${dragY}px)`,
-					transition: isDragging ? "none" : "transform 0.25s ease",
-					willChange: "transform",
-					paddingBottom: "max(16px, env(safe-area-inset-bottom))",
+					opacity: (!isVisible || isClosing) ? 0 : 1,
+					transition: isVisible ? "opacity 0.3s ease" : "none",
 				}}
-				onClick={(e) => e.stopPropagation()}
+				onClick={isProcessing ? undefined : animateClose}
 			>
-				{!isDesktop && (
-					<div
-						className="flex justify-center pt-2.5 pb-1 cursor-grab touch-none"
-						onTouchStart={onTouchStart}
-						onTouchMove={onTouchMove}
-						onTouchEnd={onTouchEnd}
-					>
-						<div className="h-1 w-10 rounded-full bg-[var(--border)]" />
-					</div>
-				)}
-				{isDesktop && <div className="pt-4" />}
-				{children}
+				<div
+					className={`flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] ${bg} shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"} ${panelClassName}`}
+					style={{
+						transform,
+						transition: isAnimating ? "transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)" : "none",
+						willChange: "transform",
+						paddingBottom: "max(16px, env(safe-area-inset-bottom))",
+					}}
+					onClick={(e) => e.stopPropagation()}
+				>
+					{!isDesktop && (
+						<div
+							className="flex justify-center pt-2.5 pb-1 cursor-grab touch-none"
+							onTouchStart={onTouchStart}
+							onTouchMove={onTouchMove}
+							onTouchEnd={onTouchEnd}
+						>
+							<div className="h-1 w-10 rounded-full bg-[var(--border)]" />
+						</div>
+					)}
+					{isDesktop && <div className="pt-4" />}
+					{children}
+				</div>
 			</div>
-		</div>
+		</BottomSheetContext.Provider>
 	);
 }

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -148,6 +148,7 @@ export function BottomSheet({
 						transition: isAnimating ? "transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)" : "none",
 						willChange: "transform",
 						paddingBottom: "max(16px, env(safe-area-inset-bottom))",
+						minHeight: isDesktop ? undefined : "50dvh",
 					}}
 					onClick={(e) => e.stopPropagation()}
 				>

--- a/src/components/ui/toggle-row.tsx
+++ b/src/components/ui/toggle-row.tsx
@@ -1,0 +1,34 @@
+export function ToggleRow({
+	checked,
+	onChange,
+	label,
+	description,
+}: {
+	checked: boolean;
+	onChange: (checked: boolean) => void;
+	label: string;
+	description?: string;
+}) {
+	return (
+		<label className={`flex min-h-14 justify-between gap-4 rounded-2xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3.5 ${description ? "items-start" : "items-center"}`}>
+			<span>
+				<span className="block text-sm font-medium">{label}</span>
+				{description ? (
+					<span className="mt-1 block text-xs leading-relaxed text-[var(--text-muted)]">
+						{description}
+					</span>
+				) : null}
+			</span>
+			<span className={`relative inline-flex h-7 w-12 flex-shrink-0 cursor-pointer items-center ${description ? "mt-1" : ""}`}>
+				<input
+					type="checkbox"
+					checked={checked}
+					onChange={(event) => onChange(event.target.checked)}
+					className="peer sr-only"
+				/>
+				<span className="absolute inset-0 rounded-full border border-[var(--border)] bg-[var(--surface)] transition-colors peer-checked:border-transparent peer-checked:bg-[var(--accent)]" />
+				<span className="absolute left-1 h-5 w-5 rounded-full bg-[var(--text)] transition-transform peer-checked:translate-x-5 peer-checked:bg-[var(--accent-contrast)]" />
+			</span>
+		</label>
+	);
+}

--- a/src/pages/app/ChatPage.tsx
+++ b/src/pages/app/ChatPage.tsx
@@ -58,6 +58,7 @@ import * as chatLog from "../../services/chatLog";
 import {
 	buildBinaryUpload,
 	extractImageHashFromSignedUrl,
+	getMessageAlbumId,
 	getMessageImageUrl,
 	getMessageMediaId,
 	getMessagePreviewLabel,
@@ -2747,6 +2748,29 @@ export function ChatPage() {
 		}
 	};
 
+	const handleStopAlbumShare = useCallback(async (albumId: number) => {
+		if (!selectedConversation || isMutatingMessageId) return;
+		const recipient = getOtherParticipant(selectedConversation, userId);
+		if (!recipient) return;
+		setIsMutatingMessageId(String(albumId));
+		try {
+			await service.stopAlbumShare(albumId, recipient.profileId);
+			toast.success(t("chat.toasts.album_share_stopped", { defaultValue: "Album share stopped." }));
+			setThreadMessages((prev) =>
+				prev.map((msg) => {
+					if (getMessageAlbumId(msg) !== albumId) return msg;
+					const body = msg.body as Record<string, unknown>;
+					return { ...msg, body: { ...body, isViewable: false, ownerProfileId: null } };
+				}),
+			);
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : t("chat.errors.album_share_failed"));
+		} finally {
+			setIsMutatingMessageId(null);
+			setOpenMessageActionId(null);
+		}
+	}, [selectedConversation, userId, isMutatingMessageId, t]);
+
 	const shareAlbumToCurrentConversation = useCallback(
 		async (albumId: number, albumName?: string | null) => {
         const targetProfile = selectedConversation
@@ -2810,6 +2834,22 @@ export function ChatPage() {
         }
     }, [loadThread, pendingAlbumShare, selectedConversation, targetProfileId, service, t, userId]);
 
+	const handleShareAlbumFromDrawer = useCallback(async (albumId: number, expirationType: string) => {
+		if (!selectedConversation) return;
+		const recipient = getOtherParticipant(selectedConversation, userId);
+		if (!recipient) return;
+		setIsSharingAlbum(true);
+		try {
+			await service.shareAlbum({ albumId, profiles: [{ profileId: recipient.profileId, expirationType: expirationType as any }] });
+			toast.success(t("chat.toasts.album_shared"));
+			void loadThread({ conversationId: selectedConversation.data.conversationId, older: false });
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : t("chat.errors.album_share_failed"));
+		} finally {
+			setIsSharingAlbum(false);
+		}
+	}, [selectedConversation, userId, t, loadThread]);
+
 	const openAlbumViewerById = useCallback(
 		async (albumId: number) => {
 			setIsAlbumViewerLoading(true);
@@ -2859,15 +2899,8 @@ export function ChatPage() {
 			return;
 		}
 
-		const albums = shareableAlbums.length > 0 ? shareableAlbums : await loadAlbums();
-		const shareable = albums.filter((album) => album.isShareable);
-
-		if (shareable.length === 1) {
-			void shareAlbumToCurrentConversation(
-				shareable[0].albumId,
-				shareable[0].albumName,
-			);
-			return;
+		if (shareableAlbums.length === 0) {
+			await loadAlbums();
 		}
 
 		setIsAlbumPickerOpen(true);
@@ -2904,10 +2937,11 @@ export function ChatPage() {
 		}
 
 		setIsDrawerOpen(true);
-		if (drawerMedia.length === 0) {
-			await loadDrawerMedia();
-		}
-	}, [isDrawerOpen, drawerMedia.length, loadDrawerMedia]);
+		const [, ] = await Promise.all([
+			drawerMedia.length === 0 ? loadDrawerMedia() : Promise.resolve(),
+			shareableAlbums.length === 0 ? loadAlbums() : Promise.resolve(),
+		]);
+	}, [isDrawerOpen, drawerMedia.length, loadDrawerMedia, shareableAlbums.length, loadAlbums]);
 
 	const sendDrawerMedia = useCallback(
 		async (mediaIds: number[], isExpiring?: boolean) => {
@@ -3222,6 +3256,7 @@ export function ChatPage() {
 			handleDelete={handleDelete}
 			handleRetry={handleRetry}
 			handleReply={handleReplyToMessage}
+			handleStopAlbumShare={handleStopAlbumShare}
 			threadBottomRef={threadBottomRef}
 			handleSend={handleSend}
 			toggleAlbumPicker={toggleAlbumPicker}
@@ -3256,6 +3291,8 @@ export function ChatPage() {
 			onSendDrawerMedia={sendDrawerMedia}
 			onAddDrawerMedia={addDrawerMedia}
 			onDeleteDrawerMedia={deleteDrawerMedia}
+			onShareAlbumFromDrawer={handleShareAlbumFromDrawer}
+			onStopAlbumShareFromDrawer={handleStopAlbumShare}
 			onSendLocation={sendLocationMessage}
 			uploadProgress={uploadProgress}
 			draft={draft}

--- a/src/pages/app/ChatPage.tsx
+++ b/src/pages/app/ChatPage.tsx
@@ -2912,14 +2912,13 @@ export function ChatPage() {
 	]);
 
 	const loadDrawerMedia = useCallback(async () => {
-		if (!selectedConversationId) {
-			return;
-		}
+		const cid = selectedConversationId ?? conversations[0]?.data.conversationId;
+		if (!cid) return;
 
 		setIsLoadingDrawer(true);
 		setDrawerError(null);
 		try {
-			const media = await service.getDrawerMedia(selectedConversationId);
+			const media = await service.getDrawerMedia(cid);
 			setDrawerMedia(media);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : t("chat.errors.load_drawer_media");
@@ -2928,7 +2927,7 @@ export function ChatPage() {
 		} finally {
 			setIsLoadingDrawer(false);
 		}
-	}, [selectedConversationId, service, t]);
+	}, [selectedConversationId, conversations, service, t]);
 
 	const toggleDrawer = useCallback(async () => {
 		if (isDrawerOpen) {

--- a/src/pages/app/ChatPage.tsx
+++ b/src/pages/app/ChatPage.tsx
@@ -592,7 +592,25 @@ export function ChatPage() {
 	}, [selectedConversation]);
 	useEffect(() => {
 		setPendingAlbumShare(null);
+		setAlbumViewer(null);
+		setAlbumViewerMediaIndex(null);
 	}, [selectedConversationId]);
+
+	const isAlbumOpen = albumViewer !== null;
+	useEffect(() => {
+		if (!isAlbumOpen) return;
+		const prevState = history.state;
+		history.pushState({ albumOpen: true }, "");
+		const onPopState = () => {
+			setAlbumViewer(null);
+			setAlbumViewerMediaIndex(null);
+		};
+		window.addEventListener("popstate", onPopState);
+		return () => {
+			window.removeEventListener("popstate", onPopState);
+			if (history.state?.albumOpen) history.replaceState(prevState, "");
+		};
+	}, [isAlbumOpen]);
 
 	const messageSearchResults = useMemo(
 		() => searchMessagesLocal(searchQuery, { limit: 80 }),
@@ -3248,6 +3266,7 @@ export function ChatPage() {
 			selectedActionMessage={selectedActionMessage}
 			selectedActionMessageMine={selectedActionMessageMine}
 			albumViewer={albumViewer}
+			onCloseAlbumViewer={() => { setAlbumViewer(null); setAlbumViewerMediaIndex(null); }}
 		/>
 	);
 

--- a/src/pages/app/ChatPage.tsx
+++ b/src/pages/app/ChatPage.tsx
@@ -79,6 +79,7 @@ import type { ChatContactIndexRecord } from "../../types/chat-contact-index";
 import { markInboxSeen } from "../../services/seenStore";
 import { shouldAutoBlock, isOutsideAgeLimits } from "../../utils/autoblock";
 import { isChatGhosted } from "../../utils/privacy";
+import freegrindLogo from "../../images/freegrind-logo.webp";
 
 export function ChatPage() {
 	const { t } = useTranslation();
@@ -364,9 +365,12 @@ export function ChatPage() {
 		number | null
 	>(null);
 	const [isAlbumViewerLoading, setIsAlbumViewerLoading] = useState(false);
-	const [fullScreenImageUrl, setFullScreenImageUrl] = useState<string | null>(
-		null,
-	);
+	const [fullScreenImageUrl, setFullScreenImageUrl] = useState<string | null>(null);
+	const [fullScreenImageMeta, setFullScreenImageMeta] = useState<{
+		takenOnGrindr: boolean;
+		createdAtLabel: string | null;
+		timestamp: number;
+	} | null>(null);
 
 	const [isUploadingAttachment, setIsUploadingAttachment] = useState(false);
 	const [uploadProgress, setUploadProgress] = useState(0);
@@ -3048,8 +3052,9 @@ export function ChatPage() {
 		setAttachmentTakenOnGrindr(false);
 	};
 
-	const openFullScreenImage = useCallback((imageUrl: string) => {
+	const openFullScreenImage = useCallback((imageUrl: string, meta?: { takenOnGrindr: boolean; createdAtLabel: string | null; timestamp: number }) => {
 		setFullScreenImageUrl(imageUrl);
+		setFullScreenImageMeta(meta ?? null);
 	}, []);
 
 	const closeFullScreenImage = useCallback(() => {
@@ -3356,6 +3361,20 @@ export function ChatPage() {
 				isOpen={!!fullScreenImageUrl}
 				onClose={closeFullScreenImage}
 				photos={fullScreenImageUrl ? [fullScreenImageUrl] : []}
+				renderExtraInfo={fullScreenImageMeta ? () => (
+                    <div className="flex items-center gap-2 text-xs text-white/80">
+						{fullScreenImageMeta.takenOnGrindr && (
+							<span className="inline-flex items-center gap-1">
+								<img src={freegrindLogo} alt={t("chat.thread.taken_on_grindr")} className="h-5 w-5 rounded-full logo-shine" />
+							</span>
+						)}
+						{fullScreenImageMeta.createdAtLabel && (
+							<span className="rounded-full bg-black/50 px-2 py-0.5 text-[10px] backdrop-blur-sm">
+								{fullScreenImageMeta.createdAtLabel}
+							</span>
+						)}
+					</div>
+				) : undefined}
 			/>
 		</section>
 	);

--- a/src/pages/app/ChatPage.tsx
+++ b/src/pages/app/ChatPage.tsx
@@ -64,6 +64,7 @@ import {
 	getOtherParticipant,
 	isLocalClientMessageId,
 	parseChatFiltersFromLocationState,
+    formatDateTime24
 } from "./chat/chatUtils";
 import { useDesktopBreakpoint } from "../../hooks/useDesktopBreakpoint";
 import { appLog } from "../../utils/logger";
@@ -3362,18 +3363,22 @@ export function ChatPage() {
 				onClose={closeFullScreenImage}
 				photos={fullScreenImageUrl ? [fullScreenImageUrl] : []}
 				renderExtraInfo={fullScreenImageMeta ? () => (
-                    <div className="flex items-center gap-2 text-xs text-white/80">
-						{fullScreenImageMeta.takenOnGrindr && (
-							<span className="inline-flex items-center gap-1">
-								<img src={freegrindLogo} alt={t("chat.thread.taken_on_grindr")} className="h-5 w-5 rounded-full logo-shine" />
-							</span>
-						)}
-						{fullScreenImageMeta.createdAtLabel && (
-							<span className="rounded-full bg-black/50 px-2 py-0.5 text-[10px] backdrop-blur-sm">
-								{fullScreenImageMeta.createdAtLabel}
-							</span>
-						)}
-					</div>
+                    <p className="inline-flex items-center gap-1 rounded-full bg-black/65 px-3 py-1 text-xs font-semibold text-white ring-1 ring-white/25">
+                        <style>{`
+                            @keyframes logo-shine { 0%, 100% { filter: drop-shadow(0 0 2px rgba(255,140,0,0.3)) brightness(1); } 50% { filter: drop-shadow(0 0 7px rgba(255,140,0,0.95)) brightness(1.25); } }
+                            .logo-shine { animation: logo-shine 2.8s ease-in-out infinite; }
+                        `}</style>
+                        {fullScreenImageMeta.takenOnGrindr ? (
+                            <img
+                                src={freegrindLogo}
+                                alt={t("chat.thread.taken_on_grindr")}
+                                className="h-3.5 w-3.5 rounded-full logo-shine"
+                            />
+                        ) : null}
+                        {fullScreenImageMeta.timestamp ? (
+                            <span>{formatDateTime24(fullScreenImageMeta.timestamp)}</span>
+                        ) : null}
+                    </p>
 				) : undefined}
 			/>
 		</section>

--- a/src/pages/app/ChatPage.tsx
+++ b/src/pages/app/ChatPage.tsx
@@ -1583,6 +1583,9 @@ export function ChatPage() {
 			setThreadError(null);
 			setReplyTargetMessageId(null);
 			lastLoadedConversationIdRef.current = null;
+			setIsDrawerOpen(false);
+			setDrawerMedia([]);
+			setPendingAttachmentFile(null);
 			return;
 		}
 
@@ -2525,6 +2528,19 @@ export function ChatPage() {
 		sendMediaAttachment,
 	]);
 
+	const confirmAttachmentFile = useCallback(
+		(file: File) => {
+			void sendMediaAttachment(file, {
+				looping: attachmentLooping,
+				takenOnGrindr: attachmentTakenOnGrindr,
+			});
+			setPendingAttachmentFile(null);
+			setAttachmentLooping(false);
+			setAttachmentTakenOnGrindr(false);
+		},
+		[attachmentLooping, attachmentTakenOnGrindr, sendMediaAttachment],
+	);
+
 	const handleSend = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		void sendTextMessage(draft);
@@ -3195,6 +3211,7 @@ export function ChatPage() {
 			setAttachmentLooping={setAttachmentLooping}
 			setAttachmentTakenOnGrindr={setAttachmentTakenOnGrindr}
 			confirmPendingAttachment={confirmPendingAttachment}
+			confirmAttachmentFile={confirmAttachmentFile}
 			cancelPendingAttachment={cancelPendingAttachment}
 			isAlbumPickerOpen={isAlbumPickerOpen}
 			isLoadingAlbums={isLoadingAlbums}

--- a/src/pages/app/ProfileEditorPage.tsx
+++ b/src/pages/app/ProfileEditorPage.tsx
@@ -660,15 +660,11 @@ export function ProfileEditorPage() {
 	return (
 		<section className="app-screen">
 			<div className="mx-auto grid w-full max-w-[1180px] gap-6">
-				<header className="space-y-3">
-					<p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-						{t("profile_editor.management")}
-					</p>
-					<h1 className="app-title">{t("profile_editor.title")}</h1>
-					<p className="max-w-[65ch] text-sm leading-relaxed text-[var(--text-muted)] sm:text-base">
-						{t("profile_editor.subtitle")}
-					</p>
-				</header>
+                <header>
+                    <BackToSettings />
+                    <h1 className="app-title mb-2">{t("profile_editor.title")}</h1>
+                    <p className="app-subtitle">{t("profile_editor.subtitle")}</p>
+                </header>
 
 				{isLoadingProfile && !profile ? (
 					<div className="surface-card rounded-3xl p-5 sm:p-6">
@@ -814,16 +810,6 @@ export function ProfileEditorPage() {
 						</div>
 					</div>
 				)}
-
-				<div className="mt-1 flex flex-wrap items-center gap-3">
-					<BackToSettings />
-					<button
-						onClick={handleLogout}
-						className="btn-accent min-h-11 px-4 py-2.5 font-semibold"
-					>
-						{t("settings.logout")}
-					</button>
-				</div>
 			</div>
 		</section>
 	);

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -1,11 +1,14 @@
 import {
 	ArrowDown,
 	ArrowUp,
+	Check,
 	Images,
 	Pencil,
 	Plus,
+	RefreshCcw,
 	Trash2,
 	Upload,
+	X,
 } from "lucide-react";
 import { BackToSettings } from "../../components/BackToSettings";
 import {
@@ -408,57 +411,54 @@ export function SettingsAlbumsPage() {
 				</header>
 
 				<section className="surface-card p-5 sm:p-6">
-					<div className="mb-4">
-						<div className="flex items-center gap-2">
-							<Images className="h-5 w-5" />
-							<h2 className="text-lg font-semibold">{t("settings_albums.your_albums")}</h2>
-						</div>
-						{!canCreateAlbum && (
-							<p className="mt-0.5 text-sm text-[var(--text-muted)]">{t("settings_albums.limit_reached")}</p>
-						)}
-						<div className="mt-3 flex items-center gap-2">
-							<input
-								type="text"
-								value={createName}
-								onChange={(event) => setCreateName(event.target.value)}
-								placeholder={t("settings_albums.new_album_placeholder")}
-								className="input-field h-11 min-w-0 flex-1"
-								maxLength={255}
-							/>
-							<Button
-								type="button"
-								onClick={handleCreateAlbum}
-								disabled={!canCreateAlbum || isCreating}
-								variant="primary"
-							>
-								<Plus className="h-4 w-4" />
-								{isCreating ? t("settings_albums.creating") : t("settings_albums.create")}
-							</Button>
-						</div>
-						<div className="mt-4 h-px bg-[var(--border)]" />
+					<div className="flex items-center gap-2">
+						<Images className="h-5 w-5" />
+						<h2 className="text-lg font-semibold">{t("settings_albums.your_albums")}</h2>
 					</div>
-					{isLoading ? (
-						<LoadingState
-							title={t("settings_albums.loading")}
-							description={t("settings_albums.loading_desc")}
-							compact
+					{!canCreateAlbum && (
+						<p className="mt-0.5 text-sm text-[var(--text-muted)]">{t("settings_albums.limit_reached")}</p>
+					)}
+					<div className="mt-3 flex items-center gap-2">
+						<input
+							type="text"
+							value={createName}
+							onChange={(event) => setCreateName(event.target.value)}
+							placeholder={t("settings_albums.new_album_placeholder")}
+							className="input-field h-11 min-w-0 flex-1"
+							maxLength={255}
 						/>
-					) : error ? (
-						<ErrorState
-							title={t("settings_albums.error_load")}
-							description={error}
-							onRetry={() => {
-								void loadAlbumsAndLimits();
-							}}
-						/>
-					) : albums.length === 0 ? (
-						<EmptyState
-							title={t("settings_albums.empty")}
-							description={t("settings_albums.empty_desc")}
-						/>
-					) : (
-						<div className="grid gap-3">
-							{albums.map((album) => {
+						<Button
+							type="button"
+							onClick={handleCreateAlbum}
+							disabled={!canCreateAlbum || isCreating}
+							variant="primary"
+						>
+							<Plus className="h-4 w-4" />
+							{isCreating ? t("settings_albums.creating") : t("settings_albums.create")}
+						</Button>
+					</div>
+					</section>
+
+				{isLoading ? (
+					<LoadingState
+						title={t("settings_albums.loading")}
+						description={t("settings_albums.loading_desc")}
+						compact
+					/>
+				) : error ? (
+					<ErrorState
+						title={t("settings_albums.error_load")}
+						description={error}
+						onRetry={() => void loadAlbumsAndLimits()}
+					/>
+				) : albums.length === 0 ? (
+					<EmptyState
+						title={t("settings_albums.empty")}
+						description={t("settings_albums.empty_desc")}
+					/>
+				) : (
+					<>
+						{albums.map((album) => {
 								const isEditing = editingAlbumId === album.albumId;
 								const isOpen = openAlbumId === album.albumId;
 								const detail = albumDetails[album.albumId];
@@ -472,7 +472,7 @@ export function SettingsAlbumsPage() {
 								return (
 									<div
 										key={album.albumId}
-										className="rounded-2xl border border-[var(--border)] bg-[var(--surface-2)] p-3 sm:p-4"
+										className="surface-card p-4 sm:p-5"
 									>
 										<div className="flex items-center gap-3">
 											{coverUrl ? (
@@ -488,7 +488,7 @@ export function SettingsAlbumsPage() {
 														type="text"
 														value={editingName}
 														onChange={(event) => setEditingName(event.target.value)}
-														className="input-field h-11 w-full"
+														className="input-field w-full [min-height:0] !py-1.5 h-9"
 														maxLength={255}
 													/>
 												) : (
@@ -509,16 +509,20 @@ export function SettingsAlbumsPage() {
 															type="button"
 															onClick={() => void saveEditingAlbum(album.albumId)}
 															disabled={isSavingEdit}
-															className="btn-accent inline-flex h-11 items-center rounded-xl px-3 text-sm"
+															className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-[var(--accent)] text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+														
+															title={t("settings_albums.save")}
 														>
-															{isSavingEdit ? t("settings_albums.saving") : t("settings_albums.save")}
+															<Check className="h-4 w-4" />
 														</button>
 														<button
 															type="button"
 															onClick={cancelEditing}
-															className="inline-flex h-11 items-center rounded-xl border border-[var(--border)] px-3 text-sm"
+															className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] transition hover:border-[var(--text-muted)]"
+														
+															title={t("settings_albums.cancel")}
 														>
-															{t("settings_albums.cancel")}
+															<X className="h-4 w-4" />
 														</button>
 													</>
 												) : (
@@ -552,62 +556,44 @@ export function SettingsAlbumsPage() {
 										</div>
 
 										{isOpen && (
-											<div className="mt-4 grid gap-3 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-3 sm:p-4">
-												<div className="flex flex-wrap items-center justify-between gap-3">
-													<div>
-														<p className="text-sm font-semibold">{t("settings_albums.media_title")}</p>
-														<p className="text-xs text-[var(--text-muted)]">
-															{t("settings_albums.media_counts_images", { count: mediaCounts.images })}
-															{mediaCounts.nonImages > 0
-																? t("settings_albums.media_counts_total", { count: mediaCounts.total })
-																: ""}
-															{t("settings_albums.media_desc")}
-														</p>
-													</div>
-
-													<div className="flex items-center gap-2">
+											<div className="mt-3">
+											<div className="-mx-4 mb-3 h-px bg-[var(--border)] sm:-mx-5" />
+												<div className="mb-2.5 flex items-center justify-between gap-2">
+													<p className="text-xs text-[var(--text-muted)]">
+														{t("settings_albums.media_counts_images", { count: mediaCounts.images })}
+														{mediaCounts.nonImages > 0 ? t("settings_albums.media_counts_total", { count: mediaCounts.total }) : ""}
+													</p>
+													<div className="flex items-center gap-1.5">
 														<input
 															id={uploadInputId}
 															type="file"
 															accept="image/*"
 															multiple
-															onChange={(event) =>
-																void handleUploadInputChange(
-																	album.albumId,
-																	event,
-																)
-															}
+															onChange={(event) => void handleUploadInputChange(album.albumId, event)}
 															className="hidden"
 														/>
 														<label
 															htmlFor={uploadInputId}
-															className="inline-flex cursor-pointer items-center gap-1 rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
+															className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--border)] px-2.5 text-xs transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
 														>
 															<Upload className="h-3.5 w-3.5" />
-															{uploadingAlbumId === album.albumId
-																? t("settings_albums.uploading")
-																: t("settings_albums.upload")}
+															{uploadingAlbumId === album.albumId ? t("settings_albums.uploading") : t("settings_albums.upload")}
 														</label>
 														<button
 															type="button"
-															onClick={() =>
-																void loadAlbumDetails(album.albumId, true)
-															}
-															className="rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
+															onClick={() => void loadAlbumDetails(album.albumId, true)}
+															className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+															title={t("settings_albums.refresh")}
 														>
-															{t("settings_albums.refresh")}
+															<RefreshCcw className="h-3.5 w-3.5" />
 														</button>
 													</div>
 												</div>
 
 												{isLoadingDetails ? (
-													<p className="text-sm text-[var(--text-muted)]">
-														{t("settings_albums.loading_media")}
-													</p>
+													<p className="text-sm text-[var(--text-muted)]">{t("settings_albums.loading_media")}</p>
 												) : !detail || detail.content.length === 0 ? (
-													<p className="text-sm text-[var(--text-muted)]">
-														{t("settings_albums.no_media")}
-													</p>
+													<p className="text-sm text-[var(--text-muted)]">{t("settings_albums.no_media")}</p>
 												) : (
 													<div className={`grid gap-3 ${isDesktop ? "grid-cols-6" : "grid-cols-2"}`}>
 														{detail.content.map((item, index) => {
@@ -670,14 +656,14 @@ export function SettingsAlbumsPage() {
 														})}
 													</div>
 												)}
-											</div>
-										)}
-									</div>
+										</div>
+									)}
+								</div>
 								);
 							})}
-						</div>
-					)}
-				</section>
+					</>
+				)}
+
 			</div>
 
 			<ConfirmDialog

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
 import { useApiFunctions } from "../../hooks/useApiFunctions";
 import { Button } from "../../components/ui/button";
+import { ConfirmDialog } from "../../components/ui/confirm-dialog";
 import {
 	EmptyState,
 	ErrorState,
@@ -392,48 +393,44 @@ export function SettingsAlbumsPage() {
 	return (
 		<section className="app-screen">
 			<div className="mx-auto grid w-full max-w-4xl gap-6">
-				<header className="mb-6">
+				<header>
 					<BackToSettings />
-					<h1 className="app-title mb-2">{t("settings_albums.title")}</h1>
+					<h1 className="app-title mb-1">{t("settings_albums.title")}</h1>
 					<p className="app-subtitle">
 						{freePlanHint} {t("settings_albums.usage", { count: albums.length, max: maxAlbums })}
 					</p>
 				</header>
 
 				<section className="surface-card p-5 sm:p-6">
-					<div className="flex flex-wrap items-center gap-3">
-						<input
-							type="text"
-							value={createName}
-							onChange={(event) => setCreateName(event.target.value)}
-							placeholder={t("settings_albums.new_album_placeholder")}
-							className="input-field max-w-md"
-							maxLength={255}
-						/>
-						<Button
-							type="button"
-							onClick={handleCreateAlbum}
-							disabled={!canCreateAlbum || isCreating}
-							variant="primary"
-						>
-							<Plus className="h-4 w-4" />
-							{isCreating ? t("settings_albums.creating") : t("settings_albums.create")}
-						</Button>
+					<div className="mb-4">
+						<div className="flex items-center gap-2">
+							<Images className="h-5 w-5" />
+							<h2 className="text-lg font-semibold">{t("settings_albums.your_albums")}</h2>
+						</div>
+						{!canCreateAlbum && (
+							<p className="mt-0.5 text-sm text-[var(--text-muted)]">{t("settings_albums.limit_reached")}</p>
+						)}
+						<div className="mt-3 flex items-center gap-2">
+							<input
+								type="text"
+								value={createName}
+								onChange={(event) => setCreateName(event.target.value)}
+								placeholder={t("settings_albums.new_album_placeholder")}
+								className="input-field h-11 min-w-0 flex-1"
+								maxLength={255}
+							/>
+							<Button
+								type="button"
+								onClick={handleCreateAlbum}
+								disabled={!canCreateAlbum || isCreating}
+								variant="primary"
+							>
+								<Plus className="h-4 w-4" />
+								{isCreating ? t("settings_albums.creating") : t("settings_albums.create")}
+							</Button>
+						</div>
+						<div className="mt-4 h-px bg-[var(--border)]" />
 					</div>
-
-					{!canCreateAlbum && (
-						<p className="mt-3 text-sm text-[var(--text-muted)]">
-							{t("settings_albums.limit_reached")}
-						</p>
-					)}
-				</section>
-
-				<section className="surface-card p-5 sm:p-6">
-					<div className="mb-4 flex items-center gap-2">
-						<Images className="h-5 w-5" />
-						<h2 className="text-lg font-semibold">{t("settings_albums.your_albums")}</h2>
-					</div>
-
 					{isLoading ? (
 						<LoadingState
 							title={t("settings_albums.loading")}
@@ -463,53 +460,57 @@ export function SettingsAlbumsPage() {
 									loadingAlbumDetailsId === album.albumId;
 								const uploadInputId = `album-upload-${album.albumId}`;
 								const mediaCounts = countAlbumMedia(detail);
-								const isConfirmingAlbumDelete =
-									confirmDeleteAlbumId === album.albumId;
+
+								const coverUrl = detail?.content[0]?.thumbUrl || detail?.content[0]?.url || detail?.content[0]?.coverUrl;
 
 								return (
 									<div
 										key={album.albumId}
 										className="rounded-2xl border border-[var(--border)] bg-[var(--surface-2)] p-3 sm:p-4"
 									>
-										<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-											{isEditing ? (
-												<input
-													type="text"
-													value={editingName}
-													onChange={(event) =>
-														setEditingName(event.target.value)
-													}
-													className="input-field w-full sm:max-w-md"
-													maxLength={255}
-												/>
+										<div className="flex items-center gap-3">
+											{coverUrl ? (
+												<img src={coverUrl} alt="" className="h-12 w-12 shrink-0 rounded-xl object-cover" />
 											) : (
-												<div className="min-w-0 flex-1">
-													<p className="truncate text-base font-semibold">
-														{album.albumName?.trim() || t("settings_albums.untitled")}
-													</p>
-													<p className="break-all text-xs text-[var(--text-muted)]">
-														{t("settings_albums.album_id", { id: album.albumId })}
-													</p>
+												<div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[var(--surface)] text-[var(--text-muted)]">
+													<Images className="h-5 w-5 opacity-40" />
 												</div>
 											)}
-
-											<div className="flex flex-wrap items-center gap-2 sm:justify-end">
+											<div className="min-w-0 flex-1">
+												{isEditing ? (
+													<input
+														type="text"
+														value={editingName}
+														onChange={(event) => setEditingName(event.target.value)}
+														className="input-field w-full"
+														maxLength={255}
+													/>
+												) : (
+													<p className="truncate font-semibold">
+														{album.albumName?.trim() || t("settings_albums.untitled")}
+													</p>
+												)}
+												{!isEditing && (
+												<p className="text-xs text-[var(--text-muted)]">
+													{detail ? `${detail.content.length} ${t("settings_albums.media_title").toLowerCase()}` : `#${album.albumId}`}
+												</p>
+											)}
+											</div>
+											<div className="flex shrink-0 items-center gap-2">
 												{isEditing ? (
 													<>
 														<button
 															type="button"
-															onClick={() =>
-																void saveEditingAlbum(album.albumId)
-															}
+															onClick={() => void saveEditingAlbum(album.albumId)}
 															disabled={isSavingEdit}
-															className="btn-accent rounded-xl px-3 py-2 text-sm"
+															className="btn-accent inline-flex h-11 items-center rounded-xl px-3 text-sm"
 														>
 															{isSavingEdit ? t("settings_albums.saving") : t("settings_albums.save")}
 														</button>
 														<button
 															type="button"
 															onClick={cancelEditing}
-															className="rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
+															className="inline-flex h-11 items-center rounded-xl border border-[var(--border)] px-3 text-sm"
 														>
 															{t("settings_albums.cancel")}
 														</button>
@@ -519,7 +520,7 @@ export function SettingsAlbumsPage() {
 														<button
 															type="button"
 															onClick={() => toggleAlbumOpen(album.albumId)}
-															className="inline-flex items-center gap-1 rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
+															className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-[var(--border)] px-3 text-sm transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
 														>
 															<FolderOpen className="h-3.5 w-3.5" />
 															{isOpen ? t("settings_albums.close") : t("settings_albums.open")}
@@ -527,39 +528,20 @@ export function SettingsAlbumsPage() {
 														<button
 															type="button"
 															onClick={() => startEditingAlbum(album)}
-															className="inline-flex items-center gap-1 rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
+															className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+															title={t("settings_albums.rename")}
 														>
-															<Pencil className="h-3.5 w-3.5" /> {t("settings_albums.rename")}
+															<Pencil className="h-3.5 w-3.5" />
 														</button>
 														<button
 															type="button"
-															onClick={() => {
-																if (isConfirmingAlbumDelete) {
-																	void deleteAlbum(album.albumId);
-																	return;
-																}
-
-																setConfirmDeleteAlbumId(album.albumId);
-															}}
+															onClick={() => setConfirmDeleteAlbumId(album.albumId)}
 															disabled={deletingAlbumId === album.albumId}
-															className="inline-flex items-center gap-1 rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
+															className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] transition hover:border-red-400 hover:text-red-400"
+															title={t("settings_albums.delete")}
 														>
 															<Trash2 className="h-3.5 w-3.5" />
-															{deletingAlbumId === album.albumId
-																? t("settings_albums.deleting")
-																: isConfirmingAlbumDelete
-																	? t("settings_albums.confirm_delete")
-																	: t("settings_albums.delete")}
 														</button>
-														{isConfirmingAlbumDelete && (
-															<button
-																type="button"
-																onClick={() => setConfirmDeleteAlbumId(null)}
-																className="inline-flex items-center gap-1 rounded-xl border border-[var(--border)] px-3 py-2 text-sm"
-															>
-																{t("settings_albums.cancel")}
-															</button>
-														)}
 													</>
 												)}
 											</div>
@@ -634,13 +616,11 @@ export function SettingsAlbumsPage() {
 															const canMoveDown =
 																index < detail.content.length - 1;
 															const deleteKey = `${album.albumId}:${item.contentId}`;
-															const isConfirmingContentDelete =
-																confirmDeleteContentKey === deleteKey;
 
 															return (
 																<div
 																	key={`${album.albumId}-${item.contentId}`}
-																	className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
+																	className="relative overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
 																>
 																	{imageUrl ? (
 																		<img
@@ -652,74 +632,34 @@ export function SettingsAlbumsPage() {
 																		<div className="aspect-square w-full bg-[var(--surface)]" />
 																	)}
 
-																	<div className="grid grid-cols-3 gap-1 p-2">
-																		<button
-																			type="button"
-																			onClick={() =>
-																				void reorderAlbumContent(
-																					album.albumId,
-																					detail.content,
-																					index,
-																					index - 1,
-																				)
-																			}
-																			disabled={
-																				!canMoveUp ||
-																				reorderingAlbumId === album.albumId
-																			}
-																			className="inline-flex items-center justify-center rounded-md border border-[var(--border)] py-1"
-																		>
-																			<ArrowUp className="h-3.5 w-3.5" />
-																		</button>
-																		<button
-																			type="button"
-																			onClick={() =>
-																				void reorderAlbumContent(
-																					album.albumId,
-																					detail.content,
-																					index,
-																					index + 1,
-																				)
-																			}
-																			disabled={
-																				!canMoveDown ||
-																				reorderingAlbumId === album.albumId
-																			}
-																			className="inline-flex items-center justify-center rounded-md border border-[var(--border)] py-1"
-																		>
-																			<ArrowDown className="h-3.5 w-3.5" />
-																		</button>
-																		<button
-																			type="button"
-																			onClick={() => {
-																				if (isConfirmingContentDelete) {
-																					void deleteAlbumPicture(
-																						album.albumId,
-																						item.contentId,
-																					);
-																					return;
-																				}
-
-																				setConfirmDeleteContentKey(deleteKey);
-																			}}
-																			disabled={
-																				deletingContentKey === deleteKey
-																			}
-																			className="inline-flex items-center justify-center rounded-md border border-[var(--border)] py-1"
-																		>
-																			<Trash2 className="h-3.5 w-3.5" />
-																		</button>
-																		{isConfirmingContentDelete && (
+																	<div className="absolute inset-x-0 bottom-0 flex items-center justify-between gap-1 bg-gradient-to-t from-black/70 to-transparent p-1.5">
+																		<div className="flex gap-1">
 																			<button
 																				type="button"
-																				onClick={() =>
-																					setConfirmDeleteContentKey(null)
-																				}
-																				className="col-span-3 rounded-md border border-[var(--border)] py-1 text-xs"
+																				onClick={() => void reorderAlbumContent(album.albumId, detail.content, index, index - 1)}
+																				disabled={!canMoveUp || reorderingAlbumId === album.albumId}
+																				className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-black/50 text-white backdrop-blur-sm disabled:opacity-30"
 																			>
-																				{t("settings_albums.cancel_delete_content")}
+																				<ArrowUp className="h-3 w-3" />
 																			</button>
-																		)}
+																			<button
+																				type="button"
+																				onClick={() => void reorderAlbumContent(album.albumId, detail.content, index, index + 1)}
+																				disabled={!canMoveDown || reorderingAlbumId === album.albumId}
+																				className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-black/50 text-white backdrop-blur-sm disabled:opacity-30"
+																			>
+																				<ArrowDown className="h-3 w-3" />
+																			</button>
+																		</div>
+																		<button
+																			type="button"
+																			onClick={() => setConfirmDeleteContentKey(deleteKey)}
+																			disabled={deletingContentKey === deleteKey}
+																			className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-black/50 text-white backdrop-blur-sm disabled:opacity-30"
+																			title={t("settings_albums.delete")}
+																		>
+																			<Trash2 className="h-3 w-3" />
+																		</button>
 																	</div>
 																</div>
 															);
@@ -735,6 +675,38 @@ export function SettingsAlbumsPage() {
 					)}
 				</section>
 			</div>
+
+			<ConfirmDialog
+				isOpen={confirmDeleteAlbumId !== null}
+				title={t("settings_albums.confirm_delete")}
+				message={t("settings_albums.confirm_delete_message", {
+					defaultValue: "This album and all its content will be permanently deleted.",
+				})}
+				confirmLabel={deletingAlbumId ? t("settings_albums.deleting") : t("settings_albums.delete")}
+				cancelLabel={t("settings_albums.cancel")}
+				onConfirm={() => confirmDeleteAlbumId ? void deleteAlbum(confirmDeleteAlbumId) : undefined}
+				onCancel={() => setConfirmDeleteAlbumId(null)}
+				isProcessing={deletingAlbumId !== null}
+				confirmTone="danger"
+			/>
+
+			<ConfirmDialog
+				isOpen={confirmDeleteContentKey !== null}
+				title={t("settings_albums.confirm_delete")}
+				message={t("settings_albums.confirm_delete_content_message", {
+					defaultValue: "This image will be permanently removed from the album.",
+				})}
+				confirmLabel={deletingContentKey ? t("settings_albums.deleting") : t("settings_albums.delete")}
+				cancelLabel={t("settings_albums.cancel")}
+				onConfirm={() => {
+					if (!confirmDeleteContentKey) return;
+					const [albumId, contentId] = confirmDeleteContentKey.split(":");
+					void deleteAlbumPicture(albumId, contentId);
+				}}
+				onCancel={() => setConfirmDeleteContentKey(null)}
+				isProcessing={deletingContentKey !== null}
+				confirmTone="danger"
+			/>
 		</section>
 	);
 }

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -19,6 +19,7 @@ import {
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
 import { useApiFunctions } from "../../hooks/useApiFunctions";
+import { useDesktopBreakpoint } from "../../hooks/useDesktopBreakpoint";
 import { Button } from "../../components/ui/button";
 import { ConfirmDialog } from "../../components/ui/confirm-dialog";
 import {
@@ -39,6 +40,7 @@ import {
 
 export function SettingsAlbumsPage() {
 	const { t } = useTranslation();
+	const isDesktop = useDesktopBreakpoint();
 	const apiFunctions = useApiFunctions();
 	const [albums, setAlbums] = useState<Album[]>([]);
 	const [maxAlbums, setMaxAlbums] = useState<number>(1);
@@ -392,7 +394,7 @@ export function SettingsAlbumsPage() {
 
 	return (
 		<section className="app-screen">
-			<div className="mx-auto grid w-full max-w-4xl gap-6">
+			<div className="grid gap-6">
 				<header>
 					<BackToSettings />
 					<h1 className="app-title mb-1">{t("settings_albums.title")}</h1>
@@ -605,7 +607,7 @@ export function SettingsAlbumsPage() {
 														{t("settings_albums.no_media")}
 													</p>
 												) : (
-													<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+													<div className={`grid gap-3 ${isDesktop ? "grid-cols-6" : "grid-cols-3"}`}>
 														{detail.content.map((item, index) => {
 															const imageUrl =
 																item.thumbUrl ||

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -1,7 +1,6 @@
 import {
 	ArrowDown,
 	ArrowUp,
-	FolderOpen,
 	Images,
 	Pencil,
 	Plus,
@@ -73,6 +72,7 @@ export function SettingsAlbumsPage() {
 	const [confirmDeleteContentKey, setConfirmDeleteContentKey] = useState<
 		string | null
 	>(null);
+	const [editOpenedAlbumId, setEditOpenedAlbumId] = useState<string | null>(null);
 
 	const loadAlbumsAndLimits = useCallback(async () => {
 		setIsLoading(true);
@@ -153,6 +153,10 @@ export function SettingsAlbumsPage() {
 	};
 
 	const cancelEditing = () => {
+		if (editOpenedAlbumId) {
+			setOpenAlbumId((prev) => prev === editOpenedAlbumId ? null : prev);
+			setEditOpenedAlbumId(null);
+		}
 		setEditingAlbumId(null);
 		setEditingName("");
 	};
@@ -521,15 +525,13 @@ export function SettingsAlbumsPage() {
 													<>
 														<button
 															type="button"
-															onClick={() => toggleAlbumOpen(album.albumId)}
-															className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-[var(--border)] px-3 text-sm transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
-														>
-															<FolderOpen className="h-3.5 w-3.5" />
-															{isOpen ? t("settings_albums.close") : t("settings_albums.open")}
-														</button>
-														<button
-															type="button"
-															onClick={() => startEditingAlbum(album)}
+															onClick={() => {
+																startEditingAlbum(album);
+																if (!isOpen) {
+																	toggleAlbumOpen(album.albumId);
+																	setEditOpenedAlbumId(album.albumId);
+																}
+															}}
 															className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
 															title={t("settings_albums.rename")}
 														>

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -488,7 +488,7 @@ export function SettingsAlbumsPage() {
 														type="text"
 														value={editingName}
 														onChange={(event) => setEditingName(event.target.value)}
-														className="input-field w-full"
+														className="input-field h-11 w-full"
 														maxLength={255}
 													/>
 												) : (

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -609,7 +609,7 @@ export function SettingsAlbumsPage() {
 														{t("settings_albums.no_media")}
 													</p>
 												) : (
-													<div className={`grid gap-3 ${isDesktop ? "grid-cols-6" : "grid-cols-3"}`}>
+													<div className={`grid gap-3 ${isDesktop ? "grid-cols-6" : "grid-cols-2"}`}>
 														{detail.content.map((item, index) => {
 															const imageUrl =
 																item.thumbUrl ||

--- a/src/pages/app/SettingsAlbumsPage.tsx
+++ b/src/pages/app/SettingsAlbumsPage.tsx
@@ -392,25 +392,12 @@ export function SettingsAlbumsPage() {
 	return (
 		<section className="app-screen">
 			<div className="mx-auto grid w-full max-w-4xl gap-6">
-				<header className="grid gap-4">
+				<header className="mb-6">
 					<BackToSettings />
-
-					<div className="surface-card p-5 sm:p-6">
-						<div className="flex flex-wrap items-start justify-between gap-3">
-							<div>
-								<p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-									{t("settings_albums.label")}
-								</p>
-								<h1 className="app-title mt-2">{t("settings_albums.title")}</h1>
-								<p className="app-subtitle mt-2">
-									{freePlanHint} {t("settings_albums.usage", { count: albums.length, max: maxAlbums })}
-								</p>
-							</div>
-							<div className="rounded-2xl bg-[var(--surface-2)] p-3 text-sm font-medium">
-								{subscriptionType ?? t("settings_albums.unknown_plan")}
-							</div>
-						</div>
-					</div>
+					<h1 className="app-title mb-2">{t("settings_albums.title")}</h1>
+					<p className="app-subtitle">
+						{freePlanHint} {t("settings_albums.usage", { count: albums.length, max: maxAlbums })}
+					</p>
 				</header>
 
 				<section className="surface-card p-5 sm:p-6">

--- a/src/pages/app/SettingsPage.tsx
+++ b/src/pages/app/SettingsPage.tsx
@@ -4,6 +4,7 @@ import {
 	Bell,
 	Bookmark,
 	Bug,
+	ChevronLeft,
 	ChevronRight,
 	ClipboardList,
 	Download,
@@ -311,14 +312,24 @@ export function SettingsPage() {
 
 	return (
 		<section className="app-screen">
-			<header className="mb-6">
-				<h1 className="app-title mb-2">{t("settings.title")}</h1>
-				<p className="app-subtitle">{t("settings.subtitle")}</p>
-				{developerMode ? (
-					<p className="mt-2 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent-readable)]">
-						Developer Mode
-					</p>
-				) : null}
+			<header className="mb-6 flex items-center gap-3">
+				<button
+					type="button"
+					onClick={() => navigate("/")}
+					className="shrink-0 inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)]"
+					aria-label={t("settings.back_to_browse")}
+				>
+					<ChevronLeft className="h-4 w-4" />
+				</button>
+				<div>
+					<h1 className="app-title mb-1">{t("settings.title")}</h1>
+					<p className="app-subtitle">{t("settings.subtitle")}</p>
+					{developerMode ? (
+						<p className="mt-1 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent-readable)]">
+							Developer Mode
+						</p>
+					) : null}
+				</div>
 			</header>
 
 			<div className="grid gap-4">
@@ -807,15 +818,22 @@ export function SettingsPage() {
 					</div>
 				) : null}
 
-				<div className="mt-2 flex flex-wrap items-center gap-3">
-					<Button type="button" onClick={() => navigate("/")}>
-						{t("settings.back_to_browse")}
-					</Button>
-					<Button type="button" variant="primary" onClick={handleLogout}>
-						<LogOut className="h-4 w-4" />
+                <div className="surface-card rounded-3xl p-5 sm:p-6">
+					<p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
 						{t("settings.logout")}
-					</Button>
+					</p>
+					<p className="mt-1.5 text-sm leading-relaxed text-[var(--text-muted)]">
+						{t("profile_editor.logout_description", { defaultValue: "You will be signed out of your account on this device." })}
+					</p>
+					<button
+						type="button"
+						onClick={handleLogout}
+						className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-2.5 text-sm font-semibold text-red-400 transition hover:bg-red-500/20"
+					>
+						{t("settings.logout")}
+					</button>
 				</div>
+
 			</div>
 		</section>
 	);

--- a/src/pages/app/SettingsPage.tsx
+++ b/src/pages/app/SettingsPage.tsx
@@ -322,13 +322,15 @@ export function SettingsPage() {
 					<ChevronLeft className="h-4 w-4" />
 				</button>
 				<div>
-					<h1 className="app-title mb-1">{t("settings.title")}</h1>
+					<div className="mb-1 flex items-center gap-2">
+						<h1 className="app-title">{t("settings.title")}</h1>
+						{developerMode ? (
+							<span className="rounded-full bg-[var(--accent)] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--accent-contrast)]">
+								Developer Mode
+							</span>
+						) : null}
+					</div>
 					<p className="app-subtitle">{t("settings.subtitle")}</p>
-					{developerMode ? (
-						<p className="mt-1 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent-readable)]">
-							Developer Mode
-						</p>
-					) : null}
 				</div>
 			</header>
 

--- a/src/pages/app/SettingsPage.tsx
+++ b/src/pages/app/SettingsPage.tsx
@@ -820,17 +820,22 @@ export function SettingsPage() {
 					</div>
 				) : null}
 
-                <div className="surface-card rounded-3xl p-5 sm:p-6">
-					<p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
-						{t("settings.logout")}
-					</p>
-					<p className="mt-1.5 text-sm leading-relaxed text-[var(--text-muted)]">
-						{t("profile_editor.logout_description", { defaultValue: "You will be signed out of your account on this device." })}
-					</p>
+                <div className="surface-card flex w-full items-center justify-between p-4 text-left sm:p-5">
+					<div className="flex items-center gap-3">
+						<div className="rounded-xl bg-[var(--surface-2)] p-2.5">
+							<LogOut className="h-5 w-5" />
+						</div>
+						<div>
+							<p className="text-base font-semibold">{t("settings.logout")}</p>
+							<p className="text-sm text-[var(--text-muted)]">
+								{t("profile_editor.logout_description", { defaultValue: "You will be signed out of your account on this device." })}
+							</p>
+						</div>
+					</div>
 					<button
 						type="button"
 						onClick={handleLogout}
-						className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-2.5 text-sm font-semibold text-red-400 transition hover:bg-red-500/20"
+						className="inline-flex min-h-9 shrink-0 items-center justify-center rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm font-semibold text-red-400 transition hover:bg-red-500/20"
 					>
 						{t("settings.logout")}
 					</button>

--- a/src/pages/app/SettingsSavedPhrasesPage.tsx
+++ b/src/pages/app/SettingsSavedPhrasesPage.tsx
@@ -1,4 +1,4 @@
-import { Download, Plus, Trash2, Upload } from "lucide-react";
+import { BookMarked, Download, Plus, Trash2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -189,19 +189,24 @@ export function SettingsSavedPhrasesPage() {
 						<h2 className="text-lg font-semibold">
 							{t("settings_saved_phrases.current", { defaultValue: "Current Phrases" })}
 						</h2>
-						<span className="text-xs text-[var(--text-muted)]">
-							{t("settings_saved_phrases.count", {
-								count: savedPhrases.length,
-								defaultValue: "{{count}} saved",
-							})}
-						</span>
+						{savedPhrases.length > 0 && (
+							<span className="rounded-full bg-[var(--surface-2)] px-2 py-0.5 text-[11px] font-semibold tabular-nums text-[var(--text-muted)]">
+								{savedPhrases.length}
+							</span>
+						)}
 					</div>
 					{savedPhrases.length === 0 ? (
-						<p className="text-sm text-[var(--text-muted)]">
-							{t("settings_saved_phrases.empty", {
-								defaultValue: "No saved phrases yet.",
-							})}
-						</p>
+						<div className="flex flex-col items-center gap-2.5 py-8 text-[var(--text-muted)]">
+							<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--surface-2)]">
+								<BookMarked className="h-5 w-5 opacity-60" />
+							</div>
+							<p className="text-sm font-medium">
+								{t("settings_saved_phrases.empty", { defaultValue: "No saved phrases yet." })}
+							</p>
+							<p className="text-xs opacity-60">
+								{t("settings_saved_phrases.empty_hint", { defaultValue: "Type above to add your first phrase." })}
+							</p>
+						</div>
 					) : (
 						<div className="grid gap-2">
 							{savedPhrases.map((phrase, index) => (

--- a/src/pages/app/SettingsSavedPhrasesPage.tsx
+++ b/src/pages/app/SettingsSavedPhrasesPage.tsx
@@ -102,11 +102,8 @@ export function SettingsSavedPhrasesPage() {
 
 	return (
 		<section className="app-screen">
-			<BackToSettings />
 			<header className="mb-6">
-				<p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--accent-readable)]">
-					{t("settings_saved_phrases.label", { defaultValue: "Chat" })}
-				</p>
+				<BackToSettings />
 				<h1 className="app-title mt-2">
 					{t("settings_saved_phrases.title", {
 						defaultValue: "Saved Phrases",

--- a/src/pages/app/chat/AudioMessagePlayer.tsx
+++ b/src/pages/app/chat/AudioMessagePlayer.tsx
@@ -37,7 +37,7 @@ export function AudioMessagePlayer({ src, messageId, mine }: Props) {
 	const [speedIdx, setSpeedIdx] = useState(0);
 
 	const waveform = seededWaveform(messageId, BARS);
-	const progress = duration > 0 ? currentTime / duration : 0;
+
 
 	const rafRef = useRef<number | null>(null);
 	const clipRef = useRef<HTMLDivElement | null>(null);
@@ -135,7 +135,7 @@ export function AudioMessagePlayer({ src, messageId, mine }: Props) {
 
 	return (
 		<div className="flex w-64 items-center gap-2.5 py-1">
-			<audio ref={audioRef} src={src} preload="metadata" className="hidden" />
+			<audio ref={audioRef} src={src} preload="metadata" className="absolute w-0 h-0 opacity-0 pointer-events-none overflow-hidden" />
 
 			<button
 				type="button"

--- a/src/pages/app/chat/AudioMessagePlayer.tsx
+++ b/src/pages/app/chat/AudioMessagePlayer.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Pause, Play } from "lucide-react";
+
+function formatDuration(seconds: number) {
+	const m = Math.floor(seconds / 60);
+	const s = Math.floor(seconds % 60);
+	return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function seededWaveform(seed: string, bars: number): number[] {
+	let h = 0;
+	for (let i = 0; i < seed.length; i++) {
+		h = Math.imul(31, h) + seed.charCodeAt(i) | 0;
+	}
+	return Array.from({ length: bars }, () => {
+		h = Math.imul(1664525, h) + 1013904223 | 0;
+		return 0.25 + (Math.abs(h) / 0x7fffffff) * 0.75;
+	});
+}
+
+const SPEEDS = [1, 1.5, 2] as const;
+const BARS = 36;
+
+type Props = {
+	src: string;
+	messageId: string;
+	mine: boolean;
+};
+
+export function AudioMessagePlayer({ src, messageId, mine }: Props) {
+	const audioRef = useRef<HTMLAudioElement | null>(null);
+	const trackRef = useRef<HTMLDivElement | null>(null);
+	const isDraggingRef = useRef(false);
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [currentTime, setCurrentTime] = useState(0);
+	const [duration, setDuration] = useState(0);
+	const [speedIdx, setSpeedIdx] = useState(0);
+
+	const waveform = seededWaveform(messageId, BARS);
+	const progress = duration > 0 ? currentTime / duration : 0;
+
+	const rafRef = useRef<number | null>(null);
+	const clipRef = useRef<HTMLDivElement | null>(null);
+	const durationRef = useRef(0);
+
+	const updateProgress = useCallback((t: number) => {
+		const d = durationRef.current;
+		if (clipRef.current && d > 0) {
+			clipRef.current.style.clipPath = `inset(0 ${(1 - t / d) * 100}% 0 0)`;
+		}
+	}, []);
+
+	useEffect(() => {
+		const audio = audioRef.current;
+		if (!audio) return;
+
+		const tick = () => {
+			if (!isDraggingRef.current) {
+				updateProgress(audio.currentTime);
+				setCurrentTime(audio.currentTime);
+			}
+			rafRef.current = requestAnimationFrame(tick);
+		};
+
+		const onPlay = () => { rafRef.current = requestAnimationFrame(tick); };
+		const onPause = () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+		const onMeta = () => {
+			const d = isFinite(audio.duration) ? audio.duration : 0;
+			durationRef.current = d;
+			setDuration(d);
+		};
+		const onEnded = () => {
+			if (rafRef.current) cancelAnimationFrame(rafRef.current);
+			setIsPlaying(false);
+			setCurrentTime(0);
+			updateProgress(0);
+		};
+
+		audio.addEventListener("play", onPlay);
+		audio.addEventListener("pause", onPause);
+		audio.addEventListener("loadedmetadata", onMeta);
+		audio.addEventListener("durationchange", onMeta);
+		audio.addEventListener("ended", onEnded);
+		return () => {
+			if (rafRef.current) cancelAnimationFrame(rafRef.current);
+			audio.removeEventListener("play", onPlay);
+			audio.removeEventListener("pause", onPause);
+			audio.removeEventListener("loadedmetadata", onMeta);
+			audio.removeEventListener("durationchange", onMeta);
+			audio.removeEventListener("ended", onEnded);
+		};
+	}, [updateProgress]);
+
+	const togglePlay = () => {
+		const audio = audioRef.current;
+		if (!audio) return;
+		if (isPlaying) { audio.pause(); setIsPlaying(false); }
+		else { void audio.play(); setIsPlaying(true); }
+	};
+
+	const cycleSpeed = () => {
+		const next = (speedIdx + 1) % SPEEDS.length;
+		setSpeedIdx(next);
+		if (audioRef.current) audioRef.current.playbackRate = SPEEDS[next];
+	};
+
+	const seekFromEvent = useCallback((clientX: number) => {
+		const track = trackRef.current;
+		const audio = audioRef.current;
+		const d = durationRef.current;
+		if (!track || !audio || d === 0) return;
+		const rect = track.getBoundingClientRect();
+		const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+		audio.currentTime = ratio * d;
+		setCurrentTime(ratio * d);
+		updateProgress(ratio * d);
+	}, [updateProgress]);
+
+	const onPointerDown = (e: React.PointerEvent) => {
+		isDraggingRef.current = true;
+		(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+		seekFromEvent(e.clientX);
+	};
+	const onPointerMove = (e: React.PointerEvent) => {
+		if (isDraggingRef.current) seekFromEvent(e.clientX);
+	};
+	const onPointerUp = () => { isDraggingRef.current = false; };
+
+	const barColor = mine ? "bg-[var(--accent-contrast)]" : "bg-[var(--accent)]";
+	const btnColor = mine ? "bg-[var(--accent-contrast)] text-[var(--accent)]" : "bg-[var(--accent)] text-[var(--accent-contrast)]";
+	const pillColor = mine
+		? "bg-black/20 text-[var(--accent-contrast)]"
+		: "bg-black/8 text-[var(--text)]";
+	const timeColor = mine ? "text-[var(--accent-contrast)]/60" : "text-[var(--text-muted)]";
+
+	return (
+		<div className="flex w-64 items-center gap-2.5 py-1">
+			<audio ref={audioRef} src={src} preload="metadata" className="hidden" />
+
+			<button
+				type="button"
+				onClick={togglePlay}
+				className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${btnColor} shadow-sm transition active:scale-95`}
+			>
+				{isPlaying
+					? <Pause className="h-4 w-4 fill-current" />
+					: <Play className="h-4 w-4 fill-current translate-x-[1px]" />
+				}
+			</button>
+
+			<div
+				ref={trackRef}
+				className="relative flex flex-1 h-8 cursor-pointer items-center touch-none min-w-0"
+				onPointerDown={onPointerDown}
+				onPointerMove={onPointerMove}
+				onPointerUp={onPointerUp}
+				onPointerCancel={onPointerUp}
+			>
+				{/* inactive bars */}
+				<div className="flex h-full w-full items-center gap-[2px]">
+					{waveform.map((h, i) => (
+						<div key={i} className={`flex-1 rounded-full opacity-25 ${barColor}`} style={{ height: `${Math.round(h * 100)}%` }} />
+					))}
+				</div>
+				{/* active bars — clipped via direct DOM style update */}
+				<div ref={clipRef} className="absolute inset-0 flex items-center gap-[2px]" style={{ clipPath: "inset(0 100% 0 0)" }}>
+					{waveform.map((h, i) => (
+						<div key={i} className={`flex-1 rounded-full ${barColor}`} style={{ height: `${Math.round(h * 100)}%` }} />
+					))}
+				</div>
+			</div>
+
+			<div className="flex shrink-0 flex-col items-center justify-center gap-0.5">
+				<button
+					type="button"
+					onClick={cycleSpeed}
+					className={`w-9 rounded-full py-0.5 text-center text-[11px] font-bold tabular-nums transition active:scale-95 ${pillColor}`}
+				>
+					{SPEEDS[speedIdx]}×
+				</button>
+				<span className={`text-[10px] tabular-nums ${timeColor}`}>
+					{duration > 0
+						? formatDuration(currentTime > 0 || isPlaying ? currentTime : duration)
+						: "—"}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -90,7 +90,7 @@ export function ChatDrawerPanel({
 	const [confirmDeleteMediaId, setConfirmDeleteMediaId] = useState<number | null>(null);
 	const [isExpiring, setIsExpiring] = useState(false);
 	const [selectAfterUpload, setSelectAfterUpload] = useState(false);
-	const [selectedAlbumId, setSelectedAlbumId] = useState<number | null>(null);
+	const [selectedAlbumIds, setSelectedAlbumIds] = useState<Set<number>>(new Set());
 	const EXPIRY_OPTIONS = ["INDEFINITE", "ONCE", "TEN_MINUTES", "ONE_HOUR", "ONE_DAY"];
 	const [albumExpirationType, setAlbumExpirationType] = useState("INDEFINITE");
 	const EXPIRY_LABELS: Record<string, string> = { INDEFINITE: "\u221e", ONCE: "1\u00d7", TEN_MINUTES: "10m", ONE_HOUR: "1h", ONE_DAY: "1d" };
@@ -148,7 +148,7 @@ export function ChatDrawerPanel({
 	});
 
 	const toggleSelection = useCallback((id: number) => {
-		setSelectedAlbumId(null);
+		setSelectedAlbumIds(new Set());
 		setSelectedIds((prev) => {
 			const next = new Set(prev);
 			if (next.has(id)) {
@@ -176,7 +176,7 @@ export function ChatDrawerPanel({
 	}, [selectedIds, onSendMedia, onBack, t, isExpiring]);
 
 	const hasSelection = selectedIds.size > 0;
-	const hasAlbumSelection = selectedAlbumId !== null;
+	const hasAlbumSelection = selectedAlbumIds.size > 0;
 
 	const onPickDrawerPhoto = useCallback(
 		(event: React.ChangeEvent<HTMLInputElement>) => {
@@ -475,7 +475,7 @@ export function ChatDrawerPanel({
 											) : (
 												<span className="relative inline-flex">
 													<Camera className="h-5 w-5" />
-													{!hasSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+													{!hasSelection && !hasAlbumSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
 														<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
 													</span>}
 												</span>
@@ -494,7 +494,7 @@ export function ChatDrawerPanel({
 										<div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
 											<span className="relative inline-flex">
 												<Upload className="h-5 w-5" />
-												{!hasSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+												{!hasSelection && !hasAlbumSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
 													<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
 												</span>}
 											</span>
@@ -504,15 +504,15 @@ export function ChatDrawerPanel({
 									{albums.map((album) => {
 										const cover = albumCoverMap.get(album.albumId);
 										const isShared = sharedAlbumIds.has(album.albumId);
-										const isSelected = selectedAlbumId === album.albumId;
+										const isSelected = selectedAlbumIds.has(album.albumId);
 										const dimmed = hasSelection && !isSelected;
 										return (
 											<div
 												key={`album-${album.albumId}`}
 												role="button"
 												tabIndex={0}
-												onClick={() => { if (!hasSelection) setSelectedAlbumId(isSelected ? null : album.albumId); }}
-												onKeyDown={(e) => e.key === "Enter" && !hasSelection && setSelectedAlbumId(isSelected ? null : album.albumId)}
+												onClick={() => { if (hasSelection) return; setSelectedAlbumIds(prev => { const n = new Set(prev); n.has(album.albumId) ? n.delete(album.albumId) : n.add(album.albumId); return n; }); }}
+												onKeyDown={(e) => { if (e.key === "Enter" && !hasSelection) { setSelectedAlbumIds(prev => { const n = new Set(prev); n.has(album.albumId) ? n.delete(album.albumId) : n.add(album.albumId); return n; }); } }}
 												className={`relative aspect-square overflow-hidden cursor-pointer transition ${dimmed ? "opacity-30 pointer-events-none" : ""}`}
 												style={{ outline: isSelected ? "2px solid var(--accent)" : "none", outlineOffset: "-2px" }}
 											>
@@ -522,7 +522,7 @@ export function ChatDrawerPanel({
 												<div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 to-transparent px-1.5 py-1">
 													<p className="truncate text-[9px] font-medium text-white leading-tight">{album.albumName || `#${album.albumId}`}</p>
 												</div>
-												{isShared && !isSelected ? <div className="absolute inset-0 flex items-center justify-center bg-black/40"><span className="text-[10px] font-semibold uppercase tracking-widest text-white/90">{t("chat_drawer.sharing", { defaultValue: "Sharing" })}</span></div> : null}
+												<div className="absolute inset-0 flex items-center justify-center pointer-events-none">{isShared && !isSelected ? <span className="rounded-full bg-[var(--accent)] px-2 py-0.5 text-[10px] font-semibold text-[var(--accent-contrast)]">{t("chat_drawer.sharing", { defaultValue: "Sharing" })}</span> : null}</div>
 												{isSelected ? <div className="absolute inset-0 flex items-center justify-center" style={{ background: "color-mix(in srgb, var(--accent) 45%, transparent)" }}><Check className="h-5 w-5 text-white drop-shadow" /></div> : null}
 											</div>
 										);
@@ -602,15 +602,15 @@ export function ChatDrawerPanel({
 
 						{/* Footer - Album share button */}
 						{hasAlbumSelection ? (() => {
-							const isSelectedShared = selectedAlbumId != null && sharedAlbumIds.has(selectedAlbumId);
+							const isSelectedShared = selectedAlbumIds.size > 0 && [...selectedAlbumIds].every(id => sharedAlbumIds.has(id));
 							return (
 								<div className="mt-3 -mx-4 border-t border-[var(--border)] pt-3 px-4 flex gap-2">
 									{isSelectedShared ? (
 										<button
 											type="button"
 											onClick={() => {
-												if (selectedAlbumId == null || !onStopAlbumShare) return;
-												void onStopAlbumShare(selectedAlbumId).then(() => { setSelectedAlbumId(null); onBack(); });
+												if (selectedAlbumIds.size === 0 || !onStopAlbumShare) return;
+												void Promise.all([...selectedAlbumIds].map(id => onStopAlbumShare!(id))).then(() => { setSelectedAlbumIds(new Set()); onBack(); });
 											}}
 											disabled={isSharingAlbum}
 											className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-orange-500/40 bg-orange-500/10 px-4 text-sm font-semibold text-orange-300 transition hover:bg-orange-500/20 disabled:opacity-60"
@@ -635,8 +635,8 @@ export function ChatDrawerPanel({
 											<button
 												type="button"
 												onClick={() => {
-													if (selectedAlbumId == null || !onShareAlbum) return;
-													void onShareAlbum(selectedAlbumId, albumExpirationType).then(() => { setSelectedAlbumId(null); onBack(); });
+													if (selectedAlbumIds.size === 0 || !onShareAlbum) return;
+													void Promise.all([...selectedAlbumIds].map(id => onShareAlbum!(id, albumExpirationType))).then(() => { setSelectedAlbumIds(new Set()); onBack(); });
 												}}
 												disabled={isSharingAlbum}
 												className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -55,6 +55,7 @@ interface ChatDrawerPanelProps {
 	onShareAlbum?: (albumId: number, expirationType: string) => Promise<void>;
 	isSharingAlbum?: boolean;
 	onStopAlbumShare?: (albumId: number) => Promise<void>;
+	noConversation?: boolean;
 }
 
 export function ChatDrawerPanel({
@@ -77,6 +78,7 @@ export function ChatDrawerPanel({
 	onShareAlbum,
 	isSharingAlbum = false,
 	onStopAlbumShare,
+	noConversation = false,
 }: ChatDrawerPanelProps) {
 	const { t } = useTranslation();
 	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
@@ -464,7 +466,7 @@ export function ChatDrawerPanel({
 									<button
 										type="button"
 										onClick={() => cameraInputRef.current?.click()}
-										disabled={isAdding || hasSelection || hasAlbumSelection}
+										disabled={isAdding || hasSelection || hasAlbumSelection || noConversation}
 										className="relative aspect-square bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:brightness-75"
 										aria-label={t("chat_drawer.take_photo")}
 										title={t("chat_drawer.take_photo")}
@@ -475,7 +477,7 @@ export function ChatDrawerPanel({
 											) : (
 												<span className="relative inline-flex">
 													<Camera className="h-5 w-5" />
-													{!hasSelection && !hasAlbumSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+													{!hasSelection && !hasAlbumSelection && !noConversation && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
 														<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
 													</span>}
 												</span>
@@ -486,7 +488,7 @@ export function ChatDrawerPanel({
 									<button
 										type="button"
 										onClick={() => uploadInputRef.current?.click()}
-										disabled={isAdding || hasSelection || hasAlbumSelection}
+										disabled={isAdding || hasSelection || hasAlbumSelection || noConversation}
 										className="relative aspect-square bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:brightness-75"
 										aria-label={t("chat_drawer.upload_photo")}
 										title={t("chat_drawer.upload_photo")}
@@ -494,7 +496,7 @@ export function ChatDrawerPanel({
 										<div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
 											<span className="relative inline-flex">
 												<Upload className="h-5 w-5" />
-												{!hasSelection && !hasAlbumSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+												{!hasSelection && !hasAlbumSelection && !noConversation && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
 													<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
 												</span>}
 											</span>
@@ -536,9 +538,9 @@ export function ChatDrawerPanel({
 												key={item.id}
 												role="button"
 												tabIndex={0}
-												onClick={() => { if (!hasAlbumSelection) toggleSelection(item.id); }}
-												onKeyDown={(e) => e.key === "Enter" && !hasAlbumSelection && toggleSelection(item.id)}
-												className={`relative aspect-square overflow-hidden transition cursor-pointer ${hasAlbumSelection ? "opacity-30 pointer-events-none" : ""}`}
+												onClick={() => { if (!hasAlbumSelection && !noConversation) toggleSelection(item.id); }}
+												onKeyDown={(e) => e.key === "Enter" && !hasAlbumSelection && !noConversation && toggleSelection(item.id)}
+												className={`relative aspect-square overflow-hidden transition cursor-pointer ${hasAlbumSelection || noConversation ? "opacity-30 pointer-events-none" : ""}`}
 												style={{
 													outline: isSelected ? "2px solid var(--accent)" : "none",
 													outlineOffset: "-2px",

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -1,17 +1,25 @@
 import {
+	Camera,
 	Check,
+	SquareCenterlineDashedHorizontal,
 	Image as ImageIcon,
 	Loader2,
+	RotateCw,
 	Plus,
 	Hourglass,
 	RefreshCw,
 	Send,
+	Upload,
 	X,
 } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
+import ReactCrop, { type Crop, type PixelCrop } from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
+import freegrindLogo from "../../../images/freegrind-logo.webp";
 import { ConfirmDialog } from "../../../components/ui/confirm-dialog";
+import { ToggleRow } from "../../../components/ui/toggle-row";
 import { useModalClose } from "../../../hooks/useModalClose";
 
 export interface DrawerMedia {
@@ -56,11 +64,60 @@ export function ChatDrawerPanel({
 	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 	const [pendingAddFile, setPendingAddFile] = useState<File | null>(null);
 	const [pendingTakenOnGrindr, setPendingTakenOnGrindr] = useState(false);
-	const [isAddChooserOpen, setIsAddChooserOpen] = useState(false);
+	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+	const [crop, setCrop] = useState<Crop | undefined>(undefined);
+    const [isDraggingCrop, setIsDraggingCrop] = useState(false);
+	const [completedCrop, setCompletedCrop] = useState<PixelCrop | undefined>(undefined);
+	const imgRef = useRef<HTMLImageElement | null>(null);
 	const [confirmDeleteMediaId, setConfirmDeleteMediaId] = useState<number | null>(null);
 	const [isExpiring, setIsExpiring] = useState(false);
+	const [selectAfterUpload, setSelectAfterUpload] = useState(false);
+	const prevMediaIdsRef = useRef<Set<number>>(new Set());
 	const uploadInputRef = useRef<HTMLInputElement | null>(null);
 	const cameraInputRef = useRef<HTMLInputElement | null>(null);
+
+	useEffect(() => {
+		if (!pendingAddFile) {
+			setPreviewUrl(null);
+			setCrop(undefined);
+			setCompletedCrop(undefined);
+			return;
+		}
+		const url = URL.createObjectURL(pendingAddFile);
+		setPreviewUrl(url);
+		setCrop(undefined);
+		setCompletedCrop(undefined);
+		return () => URL.revokeObjectURL(url);
+	}, [pendingAddFile]);
+
+	useEffect(() => {
+		if (!previewUrl) return;
+		setCrop({ unit: "%", x: 0, y: 0, width: 100, height: 100 });
+	}, [previewUrl]);
+
+	const applyTransform = useCallback(async (type: "flipH" | "rotateCw") => {
+		const img = imgRef.current;
+		if (!img || !img.complete || img.naturalWidth === 0) return;
+		const sw = img.naturalWidth;
+		const sh = img.naturalHeight;
+		const canvas = document.createElement("canvas");
+		canvas.width = type === "rotateCw" ? sh : sw;
+		canvas.height = type === "rotateCw" ? sw : sh;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+		ctx.translate(canvas.width / 2, canvas.height / 2);
+		if (type === "flipH") ctx.scale(-1, 1);
+		if (type === "rotateCw") ctx.rotate(Math.PI / 2);
+		ctx.drawImage(img, -sw / 2, -sh / 2, sw, sh);
+		const blob = await new Promise<Blob | null>((resolve) =>
+			canvas.toBlob(resolve, "image/jpeg", 0.95),
+		);
+		if (!blob) return;
+		setPreviewUrl((prev) => {
+			if (prev) URL.revokeObjectURL(prev);
+			return URL.createObjectURL(blob);
+		});
+	}, []);
 
 	useModalClose({
 		isOpen: true,
@@ -85,16 +142,12 @@ export function ChatDrawerPanel({
 			toast.error(t("chat_drawer.error_no_selection"));
 			return;
 		}
-
 		try {
 			await onSendMedia(Array.from(selectedIds), isExpiring);
 			setSelectedIds(new Set());
 			onBack();
 		} catch (err) {
-			const message =
-				err instanceof Error
-					? err.message
-					: t("chat_drawer.error_send_failed");
+			const message = err instanceof Error ? err.message : t("chat_drawer.error_send_failed");
 			toast.error(message);
 		}
 	}, [selectedIds, onSendMedia, onBack, t, isExpiring]);
@@ -105,9 +158,7 @@ export function ChatDrawerPanel({
 		(event: React.ChangeEvent<HTMLInputElement>) => {
 			const file = event.target.files?.[0] ?? null;
 			event.target.value = "";
-			if (!file) {
-				return;
-			}
+			if (!file) return;
 			if (!file.type.startsWith("image/")) {
 				toast.error(t("chat_drawer.invalid_file_type"));
 				return;
@@ -119,38 +170,60 @@ export function ChatDrawerPanel({
 	);
 
 	const confirmAddPhoto = useCallback(async () => {
-		if (!pendingAddFile) {
-			return;
+		if (!pendingAddFile) return;
+
+		let fileToUpload = pendingAddFile;
+		const isFullImage =
+			!completedCrop ||
+			!imgRef.current ||
+			(completedCrop.x <= 1 &&
+				completedCrop.y <= 1 &&
+				Math.abs(completedCrop.width - imgRef.current.width) <= 2 &&
+				Math.abs(completedCrop.height - imgRef.current.height) <= 2);
+		if (!isFullImage && completedCrop?.width && completedCrop.height && imgRef.current) {
+			const img = imgRef.current;
+			const scaleX = img.naturalWidth / img.width;
+			const scaleY = img.naturalHeight / img.height;
+			const canvas = document.createElement("canvas");
+			canvas.width = Math.round(completedCrop.width * scaleX);
+			canvas.height = Math.round(completedCrop.height * scaleY);
+			const ctx = canvas.getContext("2d");
+			if (ctx) {
+				ctx.drawImage(
+					img,
+					completedCrop.x * scaleX, completedCrop.y * scaleY,
+					completedCrop.width * scaleX, completedCrop.height * scaleY,
+					0, 0, canvas.width, canvas.height,
+				);
+				fileToUpload = await new Promise<File>((resolve) => {
+					canvas.toBlob((blob) => {
+						if (!blob) { resolve(pendingAddFile); return; }
+						resolve(new File([blob], pendingAddFile.name, { type: pendingAddFile.type || "image/jpeg" }));
+					}, pendingAddFile.type || "image/jpeg", 0.92);
+				});
+			}
 		}
-		await onAddMedia(pendingAddFile, pendingTakenOnGrindr);
+
+		prevMediaIdsRef.current = new Set(media.map((m) => m.id));
+		await onAddMedia(fileToUpload, pendingTakenOnGrindr);
+		setSelectedIds(new Set());
+		setSelectAfterUpload(true);
 		setPendingAddFile(null);
 		setPendingTakenOnGrindr(false);
-	}, [onAddMedia, pendingAddFile, pendingTakenOnGrindr]);
+	}, [onAddMedia, pendingAddFile, pendingTakenOnGrindr, media, completedCrop]);
+
+	useEffect(() => {
+		if (!selectAfterUpload) return;
+		const newItem = media.find((m) => !prevMediaIdsRef.current.has(m.id));
+		if (newItem) {
+			setSelectedIds(new Set([newItem.id]));
+			setSelectAfterUpload(false);
+		}
+	}, [media, selectAfterUpload]);
 
 	const cancelAddPhoto = useCallback(() => {
 		setPendingAddFile(null);
 		setPendingTakenOnGrindr(false);
-	}, []);
-
-	const openAddChooser = useCallback(() => {
-		if (isAdding) {
-			return;
-		}
-		if (isDesktop) {
-			uploadInputRef.current?.click();
-			return;
-		}
-		setIsAddChooserOpen(true);
-	}, [isAdding, isDesktop]);
-
-	const pickFromUpload = useCallback(() => {
-		setIsAddChooserOpen(false);
-		uploadInputRef.current?.click();
-	}, []);
-
-	const pickFromCamera = useCallback(() => {
-		setIsAddChooserOpen(false);
-		cameraInputRef.current?.click();
 	}, []);
 
 	const handleDeleteMedia = useCallback(
@@ -162,15 +235,10 @@ export function ChatDrawerPanel({
 	);
 
 	const confirmDeleteMedia = useCallback(async () => {
-		if (confirmDeleteMediaId == null) {
-			return;
-		}
-
+		if (confirmDeleteMediaId == null) return;
 		await onDeleteMedia(confirmDeleteMediaId);
 		setSelectedIds((previous) => {
-			if (!previous.has(confirmDeleteMediaId)) {
-				return previous;
-			}
+			if (!previous.has(confirmDeleteMediaId)) return previous;
 			const next = new Set(previous);
 			next.delete(confirmDeleteMediaId);
 			return next;
@@ -179,15 +247,13 @@ export function ChatDrawerPanel({
 	}, [confirmDeleteMediaId, onDeleteMedia]);
 
 	const cancelDeleteMedia = useCallback(() => {
-		if (deletingMediaId != null) {
-			return;
-		}
+		if (deletingMediaId != null) return;
 		setConfirmDeleteMediaId(null);
 	}, [deletingMediaId]);
 
 	return (
 		<div
-			className={`fixed inset-0 z-[60] flex items-end justify-center bg-black/45 p-4 backdrop-blur-sm no-touch-callout ${
+			className={`fixed inset-0 z-[60] flex items-end bg-black/45 backdrop-blur-sm no-touch-callout ${
 				isDesktop ? "pb-32" : ""
 			}`}
 			onClick={isSending || isAdding ? undefined : onBack}
@@ -195,286 +261,359 @@ export function ChatDrawerPanel({
 			<div
 				role="dialog"
 				aria-modal="true"
-				className="flex w-full max-w-sm flex-col rounded-2xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] p-4 shadow-2xl"
+				className="flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] px-4 pt-4 shadow-2xl mx-3"
+				style={{ paddingBottom: "max(16px, env(safe-area-inset-bottom))" }}
 				onClick={(event) => event.stopPropagation()}
 			>
 				<div className="mb-4 flex items-center justify-between">
 					<h3 className="text-sm font-semibold text-[var(--text)]">
-						{t("chat_drawer.title", { defaultValue: "Drawer" })}
+						{pendingAddFile
+							? t("chat_drawer.add_photo")
+							: t("chat_drawer.title", { defaultValue: "Drawer" })}
 					</h3>
 					<button
 						type="button"
-						onClick={onBack}
+						onClick={pendingAddFile ? cancelAddPhoto : onBack}
 						className="rounded-full p-1 text-[var(--text-muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
 					>
 						<X className="h-4 w-4" />
 					</button>
 				</div>
 
-				{/* Content Grid */}
-				<div
-					data-lenis-prevent
-					className="flex-1 overflow-y-auto max-h-[60vh] rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
-				>
-					{isLoading ? (
-					<div className="flex h-full items-center justify-center py-8">
-						<Loader2 className="h-6 w-6 animate-spin text-[var(--text-muted)]" />
-					</div>
-				) : error ? (
-					<div className="flex flex-col items-center justify-center gap-3 p-6 text-center py-8">
-						<ImageIcon className="h-8 w-8 text-[var(--text-muted)]" />
-						<p className="text-xs text-[var(--text-muted)]">{error}</p>
-						<button
-							type="button"
-							onClick={onLoadMedia}
-							className="inline-flex items-center gap-1.5 text-xs font-semibold text-[var(--accent-readable)]"
-						>
-							<RefreshCw className="h-3 w-3" />
-								{t("chat_drawer.retry")}
-						</button>
-					</div>
-				) : (
-					<div className="grid grid-cols-3 gap-0">
-						<button
-							type="button"
-							onClick={openAddChooser}
-							disabled={isAdding}
-						className="relative aspect-square border-0 bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-60"
-						aria-label={t("chat_drawer.add_photo")}
-						title={t("chat_drawer.add_photo")}
-						>
-							<div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
-								{isAdding ? (
-									<Loader2 className="h-5 w-5 animate-spin" />
-								) : (
-									<Plus className="h-5 w-5" />
+				<input type="file" ref={uploadInputRef} onChange={onPickDrawerPhoto} accept="image/*" className="hidden" />
+				<input type="file" ref={cameraInputRef} onChange={onPickDrawerPhoto} accept="image/*" capture="environment" className="hidden" />
+
+				{pendingAddFile ? (
+					<>
+						{previewUrl && (
+							<>
+							<div className="mb-4 flex justify-center">
+								<style>{`
+									.drawer-crop .ReactCrop__crop-mask { display: none !important; }
+									.drawer-crop .ReactCrop__crop-selection {
+										background-image: none !important;
+										animation: none !important;
+										outline: none !important;
+										border: 3px solid rgba(255,255,255,0.6) !important;
+										border-radius: 11px !important;
+										box-shadow: 0 0 0 9999px rgba(0,0,0,0.5) !important;
+									}
+									.drawer-crop .ord-n,
+									.drawer-crop .ord-s,
+									.drawer-crop .ord-e,
+									.drawer-crop .ord-w { display: none !important; }
+
+									.drawer-crop .ReactCrop__drag-handle {
+										background: transparent !important;
+										border: none !important;
+										width: 15px !important;
+										height: 15px !important;
+									}
+									.drawer-crop .ord-nw { transform: translate(4px, 4px) !important; border-top: 2px solid white !important; border-left: 2px solid white !important; border-top-left-radius: 4px !important; }
+									.drawer-crop .ord-ne { transform: translate(-4px, 4px) !important; border-top: 2px solid white !important; border-right: 2px solid white !important; border-top-right-radius: 4px !important; }
+									.drawer-crop .ord-sw { transform: translate(4px, -4px) !important; border-bottom: 2px solid white !important; border-left: 2px solid white !important; border-bottom-left-radius: 4px !important; }
+									.drawer-crop .ord-se { transform: translate(-4px, -4px) !important; border-bottom: 2px solid white !important; border-right: 2px solid white !important; border-bottom-right-radius: 4px !important; }
+
+									@keyframes logo-shine {
+										0%, 100% { filter: drop-shadow(0 0 2px rgba(255,140,0,0.3)) brightness(1); }
+										50% { filter: drop-shadow(0 0 7px rgba(255,140,0,0.95)) brightness(1.25); }
+									}
+									.logo-shine { animation: logo-shine 2.8s ease-in-out infinite; }
+								`}</style>
+								<div className="relative rounded-xl border border-[var(--border)] overflow-hidden">
+								<ReactCrop
+									crop={crop}
+                                    onChange={(c) => {
+                                        setIsDraggingCrop(true);
+                                        setCrop(c);
+                                    }}
+                                    onComplete={(c) => {
+                                        setIsDraggingCrop(false);
+                                        setCompletedCrop(c);
+                                    }}
+                                    ruleOfThirds={isDraggingCrop}
+									minWidth={150}
+									minHeight={150}
+									className="drawer-crop ReactCrop--no-animate"
+									style={{ maxHeight: "50dvh", display: "block" }}
+								>
+									<img
+										ref={imgRef}
+										src={previewUrl}
+										alt="Preview"
+										className="block"
+										style={{ maxHeight: "50dvh" }}
+									/>
+								</ReactCrop>
+								{pendingTakenOnGrindr && crop && (
+									<div
+										className="absolute inline-flex items-center gap-1.5 pointer-events-none"
+										style={{
+											left: `calc(${crop.unit === "%" ? crop.x + "%" : crop.x + "px"} + 10px)`,
+											top: `calc(${crop.unit === "%" ? (crop.y + crop.height) + "%" : (crop.y + crop.height) + "px"} - 10px)`,
+											transform: "translateY(-100%)",
+										}}
+									>
+										<img src={freegrindLogo} alt={t("chat.thread.taken_on_grindr")} className="h-5 w-5 rounded-full logo-shine" />
+										<span className="inline-flex items-center gap-1 rounded-full bg-black/65 px-2 py-1 text-[10px] font-semibold text-white">
+											<span>{t("chat.time.just_now", { defaultValue: "just now" })}</span>
+										</span>
+									</div>
 								)}
 							</div>
-						</button>
-						<input
-							type="file"
-							ref={uploadInputRef}
-							onChange={onPickDrawerPhoto}
-							accept="image/*"
-							className="hidden"
-						/>
-						<input
-							type="file"
-							ref={cameraInputRef}
-							onChange={onPickDrawerPhoto}
-							accept="image/*"
-							capture="environment"
-							className="hidden"
-						/>
-						{media.map((item) => {
-							const isSelected = selectedIds.has(item.id);
-							const isImage = item.contentType.startsWith("image/");
-
-							return (
+							</div>
+							<div className="mb-4 flex items-center justify-center gap-8">
 								<button
-									key={item.id}
 									type="button"
-									onClick={() => toggleSelection(item.id)}
-									className="relative aspect-square overflow-hidden border-0 transition"
-									style={{
-										borderColor: isSelected
-											? "var(--accent)"
-											: "transparent",
-										background: isSelected
-											? "color-mix(in srgb, var(--accent) 16%, var(--surface-2))"
-											: "var(--surface-2)",
-										borderWidth: isSelected ? "2px" : "0px",
-									}}
+									onClick={() => void applyTransform("flipH")}
+									className="flex flex-col items-center gap-1 text-[var(--text-muted)] transition hover:text-[var(--text)]"
+									aria-label="Flip horizontal"
 								>
-									{/* Thumbnail */}
-									{isImage ? (
-										<img
-											src={item.url}
-											alt={t("chat_drawer.media_alt")}
-											className="h-full w-full object-cover"
-										/>
-									) : (
-										<video
-											src={item.url}
-											className="h-full w-full object-cover"
-										/>
-									)}
-
-									{/* Overlay */}
-									{isSelected ? (
-										<div className="absolute inset-0 flex items-center justify-center bg-black/40">
-											<Check className="h-4 w-4 text-white" />
-										</div>
-									) : null}
-
-									{/* Used indicator */}
-									{item.used ? (
-										<div className="absolute top-0.5 right-0.5 inline-flex items-center rounded-full bg-black/60 px-1.5 py-0.5 text-[9px] font-semibold text-white">
-											✓
-										</div>
-									) : null}
-
+									<SquareCenterlineDashedHorizontal className="h-6 w-6" />
+								</button>
+								<button
+									type="button"
+									onClick={() => void applyTransform("rotateCw")}
+									className="flex flex-col items-center gap-1 text-[var(--text-muted)] transition hover:text-[var(--text)]"
+									aria-label="Rotate clockwise"
+								>
+									<RotateCw className="h-6 w-6" />
+								</button>
+							</div>
+							</>
+						)}
+						<div className="mb-4">
+							<ToggleRow
+								checked={pendingTakenOnGrindr}
+								onChange={setPendingTakenOnGrindr}
+								label={t("chat.attachments.taken_on_grindr")}
+                                description={t("chat.attachments.taken_on_grindr_description")}
+							/>
+						</div>
+						<div className="flex gap-2">
+							<button
+								type="button"
+								onClick={cancelAddPhoto}
+								disabled={isAdding}
+								className="flex-1 inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+							>
+								{t("chat.actions.cancel")}
+							</button>
+							<button
+								type="button"
+								onClick={confirmAddPhoto}
+								disabled={isAdding}
+								className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+							>
+								{isAdding ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Plus className="h-4 w-4" />
+								)}
+								<span>{isAdding ? t("chat_drawer.sending") : t("chat_drawer.add_to_drawer")}</span>
+							</button>
+						</div>
+					</>
+				) : (
+					<>
+						{/* Content Grid */}
+						<div
+							data-lenis-prevent
+							className="flex-1 overflow-y-auto max-h-[60vh] rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
+						>
+							{isLoading ? (
+								<div className="flex h-full items-center justify-center py-8">
+									<Loader2 className="h-6 w-6 animate-spin text-[var(--text-muted)]" />
+								</div>
+							) : error ? (
+								<div className="flex flex-col items-center justify-center gap-3 p-6 text-center py-8">
+									<ImageIcon className="h-8 w-8 text-[var(--text-muted)]" />
+									<p className="text-xs text-[var(--text-muted)]">{error}</p>
 									<button
 										type="button"
-										onClick={(event) => void handleDeleteMedia(event, item.id)}
-										disabled={deletingMediaId === item.id}
-										className="absolute top-0.5 left-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 disabled:opacity-60"
-								aria-label={t("chat_drawer.delete_media")}
-								title={t("chat_drawer.delete_media")}
+										onClick={onLoadMedia}
+										className="inline-flex items-center gap-1.5 text-xs font-semibold text-[var(--accent-readable)]"
 									>
-										{deletingMediaId === item.id ? (
-											<Loader2 className="h-3 w-3 animate-spin" />
-										) : (
-											<X className="h-3 w-3" />
-										)}
+										<RefreshCw className="h-3 w-3" />
+										{t("chat_drawer.retry")}
 									</button>
+								</div>
+							) : (
+								<div className="grid grid-cols-3 gap-0">
+									{/* Camera button */}
+									<button
+										type="button"
+										onClick={() => cameraInputRef.current?.click()}
+										disabled={isAdding}
+										className="relative aspect-square border-r border-b border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-60"
+										aria-label={t("chat_drawer.take_photo")}
+										title={t("chat_drawer.take_photo")}
+									>
+										<div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+											{isAdding ? (
+												<Loader2 className="h-5 w-5 animate-spin" />
+											) : (
+												<span className="relative inline-flex">
+													<Camera className="h-5 w-5" />
+													<span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+														<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
+													</span>
+												</span>
+											)}
+										</div>
+									</button>
+									{/* Upload button */}
+									<button
+										type="button"
+										onClick={() => uploadInputRef.current?.click()}
+										disabled={isAdding}
+										className="relative aspect-square border-r border-b border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-60"
+										aria-label={t("chat_drawer.upload_photo")}
+										title={t("chat_drawer.upload_photo")}
+									>
+										<div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+											<span className="relative inline-flex">
+												<Upload className="h-5 w-5" />
+												<span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+														<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
+													</span>
+											</span>
+										</div>
+									</button>
+									{media.map((item) => {
+										const isSelected = selectedIds.has(item.id);
+										const isImage = item.contentType.startsWith("image/");
+
+										return (
+											<button
+												key={item.id}
+												type="button"
+												onClick={() => toggleSelection(item.id)}
+												className="relative aspect-square overflow-hidden border-0 transition"
+												style={{
+													borderColor: isSelected ? "var(--accent)" : "transparent",
+													background: isSelected
+														? "color-mix(in srgb, var(--accent) 16%, var(--surface-2))"
+														: "var(--surface-2)",
+													borderWidth: isSelected ? "2px" : "0px",
+												}}
+											>
+												{isImage ? (
+													<img
+														src={item.url}
+														alt={t("chat_drawer.media_alt")}
+														className="h-full w-full object-cover"
+													/>
+												) : (
+													<video
+														src={item.url}
+														className="h-full w-full object-cover"
+													/>
+												)}
+
+												{isSelected ? (
+													<div className="absolute inset-0 flex items-center justify-center bg-black/40">
+														<Check className="h-4 w-4 text-white" />
+													</div>
+												) : null}
+
+												{item.used ? (
+													<div className="absolute top-0.5 right-0.5 inline-flex items-center rounded-full bg-black/60 px-1.5 py-0.5 text-[9px] font-semibold text-white">
+														✓
+													</div>
+												) : null}
+
+												<button
+													type="button"
+													onClick={(event) => void handleDeleteMedia(event, item.id)}
+													disabled={deletingMediaId === item.id}
+													className="absolute top-0.5 left-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 disabled:opacity-60"
+													aria-label={t("chat_drawer.delete_media")}
+													title={t("chat_drawer.delete_media")}
+												>
+													{deletingMediaId === item.id ? (
+														<Loader2 className="h-3 w-3 animate-spin" />
+													) : (
+														<X className="h-3 w-3" />
+													)}
+												</button>
+											</button>
+										);
+									})}
+								</div>
+							)}
+						</div>
+
+						{/* Footer - Send button */}
+						{hasSelection ? (
+							<div className="mt-3 border-t border-[var(--border)] pt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+								<button
+									type="button"
+									onClick={() => setSelectedIds(new Set())}
+									className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+								>
+									{t("chat.actions.cancel")}
 								</button>
-							);
-						})}
-					</div>
+								<div className="flex flex-1 gap-2">
+									<button
+										type="button"
+										onClick={() => setIsExpiring((prev) => !prev)}
+										className={`inline-flex h-11 min-w-[64px] items-center justify-center gap-1.5 rounded-xl border transition ${
+											isExpiring
+												? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
+												: "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"
+										}`}
+										style={{ flexBasis: "16.6%" }}
+										title={
+											isExpiring
+												? t("chat_drawer.is_expiring_title_on")
+												: t("chat_drawer.is_expiring_title_off")
+										}
+									>
+										<Hourglass className="h-4 w-4" />
+										<span className="text-sm font-semibold">
+											{isExpiring
+												? t("chat_drawer.is_expiring_toggle_on")
+												: t("chat_drawer.is_expiring_toggle_off")}
+										</span>
+									</button>
+									<button
+										type="button"
+										onClick={handleSendSelected}
+										disabled={isSending}
+										className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+									>
+										{isSending ? (
+											<Loader2 className="h-4 w-4 animate-spin" />
+										) : (
+											<Send className="h-4 w-4" />
+										)}
+										<span className="truncate">
+											{isSending
+												? t("chat_drawer.sending")
+												: isExpiring
+													? t("chat_drawer.is_expiring_send", { count: selectedIds.size })
+													: t("chat_drawer.send", { count: selectedIds.size })}
+										</span>
+									</button>
+								</div>
+							</div>
+						) : null}
+					</>
 				)}
+
+				<ConfirmDialog
+					isOpen={confirmDeleteMediaId != null}
+					title={t("chat_drawer.delete_confirm_title")}
+					message={t("chat_drawer.delete_confirm_message")}
+					confirmLabel={t("chat_drawer.delete_confirm_label")}
+					cancelLabel={t("chat.actions.cancel")}
+					onConfirm={confirmDeleteMedia}
+					onCancel={cancelDeleteMedia}
+					isProcessing={confirmDeleteMediaId != null && deletingMediaId === confirmDeleteMediaId}
+					confirmTone="danger"
+				/>
 			</div>
-
-			{isAddChooserOpen ? (
-				<div className="mt-4 border-t border-[var(--border)] pt-4">
-					<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-						<button
-							type="button"
-							onClick={() => setIsAddChooserOpen(false)}
-							className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-						>
-							{t("chat.actions.cancel")}
-						</button>
-						<button
-							type="button"
-							onClick={pickFromCamera}
-							className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-						>
-							{t("chat_drawer.take_photo")}
-						</button>
-						<button
-							type="button"
-							onClick={pickFromUpload}
-							className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-						>
-							{t("chat_drawer.upload_photo")}
-						</button>
-					</div>
-				</div>
-			) : null}
-
-			{pendingAddFile ? (
-				<div className="mt-4 border-t border-[var(--border)] pt-4">
-					<p className="mb-3 text-sm font-medium text-[var(--text)]">
-						{pendingAddFile.name}
-					</p>
-					<label className="mb-4 flex items-center gap-2 text-xs text-[var(--text-muted)]">
-						<input
-							type="checkbox"
-							checked={pendingTakenOnGrindr}
-							onChange={(event) => setPendingTakenOnGrindr(event.target.checked)}
-							disabled={isAdding}
-						/>
-						<span>{t("chat.attachments.taken_on_grindr")}</span>
-					</label>
-					<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-						<button
-							type="button"
-							onClick={cancelAddPhoto}
-							disabled={isAdding}
-							className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-						>
-							{t("chat.actions.cancel")}
-						</button>
-						<button
-							type="button"
-							onClick={confirmAddPhoto}
-							disabled={isAdding}
-							className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-						>
-							{isAdding ? (
-								<Loader2 className="h-4 w-4 animate-spin" />
-							) : (
-								<Plus className="h-4 w-4" />
-							)}
-							<span>{isAdding ? t("chat_drawer.sending") : t("chat_drawer.add_to_drawer")}</span>
-						</button>
-					</div>
-				</div>
-			) : null}
-
-			{/* Footer - Send button */}
-			{hasSelection ? (
-				<div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-					<button
-						type="button"
-						onClick={() => setSelectedIds(new Set())}
-						className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-					>
-						{t("chat.actions.cancel")}
-					</button>
-					<div className="flex flex-1 gap-2">
-						<button
-							type="button"
-							onClick={() => setIsExpiring((prev) => !prev)}
-							className={`inline-flex h-11 min-w-[64px] items-center justify-center gap-1.5 rounded-xl border transition ${
-								isExpiring
-									? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
-									: "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"
-							}`}
-							style={{ flexBasis: "16.6%" }}
-							title={
-								isExpiring
-									? t("chat_drawer.is_expiring_title_on")
-									: t("chat_drawer.is_expiring_title_off")
-							}
-						>
-							<Hourglass className="h-4 w-4" />
-							<span className="text-sm font-semibold">
-								{isExpiring
-									? t("chat_drawer.is_expiring_toggle_on")
-									: t("chat_drawer.is_expiring_toggle_off")}
-							</span>
-						</button>
-						<button
-							type="button"
-							onClick={handleSendSelected}
-							disabled={isSending}
-							className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-						>
-							{isSending ? (
-								<Loader2 className="h-4 w-4 animate-spin" />
-							) : (
-								<Send className="h-4 w-4" />
-							)}
-							<span className="truncate">
-								{isSending
-									? t("chat_drawer.sending")
-									: isExpiring
-										? t("chat_drawer.is_expiring_send", {
-												count: selectedIds.size,
-											})
-										: t("chat_drawer.send", {
-												count: selectedIds.size,
-											})}
-							</span>
-						</button>
-					</div>
-				</div>
-			) : null}
-
-			<ConfirmDialog
-				isOpen={confirmDeleteMediaId != null}
-				title={t("chat_drawer.delete_confirm_title")}
-				message={t("chat_drawer.delete_confirm_message")}
-				confirmLabel={t("chat_drawer.delete_confirm_label")}
-				cancelLabel={t("chat.actions.cancel")}
-				onConfirm={confirmDeleteMedia}
-				onCancel={cancelDeleteMedia}
-				isProcessing={confirmDeleteMediaId != null && deletingMediaId === confirmDeleteMediaId}
-				confirmTone="danger"
-			/>
 		</div>
-	</div>
 	);
 }

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -21,7 +21,7 @@ import freegrindLogo from "../../../images/freegrind-logo.webp";
 import { ConfirmDialog } from "../../../components/ui/confirm-dialog";
 import { ToggleRow } from "../../../components/ui/toggle-row";
 import { useModalClose } from "../../../hooks/useModalClose";
-import { BottomSheet } from "../../../components/ui/bottom-sheet";
+import { BottomSheet, SheetClose } from "../../../components/ui/bottom-sheet";
 
 export interface DrawerMedia {
 	id: number;
@@ -266,13 +266,15 @@ export function ChatDrawerPanel({
 							? t("chat_drawer.add_photo")
 							: t("chat_drawer.title", { defaultValue: "Drawer" })}
 					</h3>
-					<button
-						type="button"
-						onClick={pendingAddFile ? cancelAddPhoto : onBack}
-						className="rounded-full p-1 text-[var(--text-muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
-					>
-						<X className="h-4 w-4" />
-					</button>
+					{pendingAddFile ? (
+						<button type="button" onClick={cancelAddPhoto} className="rounded-full p-1 text-[var(--text-muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]">
+							<X className="h-4 w-4" />
+						</button>
+					) : (
+						<SheetClose className="rounded-full p-1 text-[var(--text-muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]">
+							<X className="h-4 w-4" />
+						</SheetClose>
+					)}
 				</div>
 
 				<input type="file" ref={uploadInputRef} onChange={onPickDrawerPhoto} accept="image/*" className="hidden" />
@@ -480,11 +482,13 @@ export function ChatDrawerPanel({
 										const isImage = item.contentType.startsWith("image/");
 
 										return (
-											<button
+											<div
 												key={item.id}
-												type="button"
+												role="button"
+												tabIndex={0}
 												onClick={() => toggleSelection(item.id)}
-												className="relative aspect-square overflow-hidden border-0 transition"
+												onKeyDown={(e) => e.key === "Enter" && toggleSelection(item.id)}
+												className="relative aspect-square overflow-hidden border-0 transition cursor-pointer"
 												style={{
 													borderColor: isSelected ? "var(--accent)" : "transparent",
 													background: isSelected
@@ -532,7 +536,7 @@ export function ChatDrawerPanel({
 														<X className="h-3 w-3" />
 													)}
 												</button>
-											</button>
+											</div>
 										);
 									})}
 								</div>

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -21,6 +21,7 @@ import freegrindLogo from "../../../images/freegrind-logo.webp";
 import { ConfirmDialog } from "../../../components/ui/confirm-dialog";
 import { ToggleRow } from "../../../components/ui/toggle-row";
 import { useModalClose } from "../../../hooks/useModalClose";
+import { BottomSheet } from "../../../components/ui/bottom-sheet";
 
 export interface DrawerMedia {
 	id: number;
@@ -252,18 +253,14 @@ export function ChatDrawerPanel({
 	}, [deletingMediaId]);
 
 	return (
-		<div
-			className="fixed inset-0 z-[60] flex items-end bg-black/45 backdrop-blur-sm no-touch-callout"
-			onClick={isSending || isAdding ? undefined : onBack}
+		<BottomSheet
+			onClose={isSending || isAdding ? () => {} : onBack}
+			isProcessing={isSending || isAdding}
+			isDesktop={isDesktop}
+			bg="bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)]"
+			panelClassName="px-4"
 		>
-			<div
-				role="dialog"
-				aria-modal="true"
-				className={`flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] px-4 pt-4 shadow-2xl ${isDesktop ? "max-w-[800px] mx-auto" : "mx-3"}`}
-				style={{ paddingBottom: "max(16px, env(safe-area-inset-bottom))" }}
-				onClick={(event) => event.stopPropagation()}
-			>
-				<div className="mb-4 flex items-center justify-between">
+			<div className="mb-4 flex items-center justify-between">
 					<h3 className="text-sm font-semibold text-[var(--text)]">
 						{pendingAddFile
 							? t("chat_drawer.add_photo")
@@ -544,7 +541,7 @@ export function ChatDrawerPanel({
 
 						{/* Footer - Send button */}
 						{hasSelection ? (
-							<div className="mt-3 border-t border-[var(--border)] pt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+							<div className="mt-3 -mx-4 border-t border-[var(--border)] pt-3 px-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
 								<button
 									type="button"
 									onClick={() => setSelectedIds(new Set())}
@@ -611,7 +608,6 @@ export function ChatDrawerPanel({
 					isProcessing={confirmDeleteMediaId != null && deletingMediaId === confirmDeleteMediaId}
 					confirmTone="danger"
 				/>
-			</div>
-		</div>
+		</BottomSheet>
 	);
 }

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -253,15 +253,13 @@ export function ChatDrawerPanel({
 
 	return (
 		<div
-			className={`fixed inset-0 z-[60] flex items-end bg-black/45 backdrop-blur-sm no-touch-callout ${
-				isDesktop ? "pb-32" : ""
-			}`}
+			className="fixed inset-0 z-[60] flex items-end bg-black/45 backdrop-blur-sm no-touch-callout"
 			onClick={isSending || isAdding ? undefined : onBack}
 		>
 			<div
 				role="dialog"
 				aria-modal="true"
-				className="flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] px-4 pt-4 shadow-2xl mx-3"
+				className={`flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] px-4 pt-4 shadow-2xl ${isDesktop ? "max-w-[800px] mx-auto" : "mx-3"}`}
 				style={{ paddingBottom: "max(16px, env(safe-area-inset-bottom))" }}
 				onClick={(event) => event.stopPropagation()}
 			>
@@ -439,7 +437,7 @@ export function ChatDrawerPanel({
 									</button>
 								</div>
 							) : (
-								<div className="grid grid-cols-3 gap-0">
+								<div className={`grid gap-0 ${isDesktop ? "grid-cols-5" : "grid-cols-3"}`}>
 									{/* Camera button */}
 									<button
 										type="button"

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -1,4 +1,5 @@
 import {
+	Album,
 	Camera,
 	Check,
 	SquareCenterlineDashedHorizontal,
@@ -9,10 +10,12 @@ import {
 	Hourglass,
 	RefreshCw,
 	Send,
+	Share2,
 	Upload,
 	X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { AlbumListItem } from "../../../types/chat-page";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
 import ReactCrop, { type Crop, type PixelCrop } from "react-image-crop";
@@ -45,6 +48,13 @@ interface ChatDrawerPanelProps {
 	deletingMediaId: number | null;
 	onDeleteMedia: (mediaId: number) => void | Promise<void>;
 	isDesktop: boolean;
+	albums?: AlbumListItem[];
+	isLoadingAlbums?: boolean;
+	albumCoverMap?: Map<number, string>;
+	sharedAlbumIds?: Set<number>;
+	onShareAlbum?: (albumId: number, expirationType: string) => Promise<void>;
+	isSharingAlbum?: boolean;
+	onStopAlbumShare?: (albumId: number) => Promise<void>;
 }
 
 export function ChatDrawerPanel({
@@ -60,6 +70,13 @@ export function ChatDrawerPanel({
 	deletingMediaId,
 	onDeleteMedia,
 	isDesktop,
+	albums = [],
+	isLoadingAlbums = false,
+	albumCoverMap = new Map(),
+	sharedAlbumIds = new Set(),
+	onShareAlbum,
+	isSharingAlbum = false,
+	onStopAlbumShare,
 }: ChatDrawerPanelProps) {
 	const { t } = useTranslation();
 	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
@@ -73,6 +90,10 @@ export function ChatDrawerPanel({
 	const [confirmDeleteMediaId, setConfirmDeleteMediaId] = useState<number | null>(null);
 	const [isExpiring, setIsExpiring] = useState(false);
 	const [selectAfterUpload, setSelectAfterUpload] = useState(false);
+	const [selectedAlbumId, setSelectedAlbumId] = useState<number | null>(null);
+	const EXPIRY_OPTIONS = ["INDEFINITE", "ONCE", "TEN_MINUTES", "ONE_HOUR", "ONE_DAY"];
+	const [albumExpirationType, setAlbumExpirationType] = useState("INDEFINITE");
+	const EXPIRY_LABELS: Record<string, string> = { INDEFINITE: "\u221e", ONCE: "1\u00d7", TEN_MINUTES: "10m", ONE_HOUR: "1h", ONE_DAY: "1d" };
 	const prevMediaIdsRef = useRef<Set<number>>(new Set());
 	const uploadInputRef = useRef<HTMLInputElement | null>(null);
 	const cameraInputRef = useRef<HTMLInputElement | null>(null);
@@ -127,6 +148,7 @@ export function ChatDrawerPanel({
 	});
 
 	const toggleSelection = useCallback((id: number) => {
+		setSelectedAlbumId(null);
 		setSelectedIds((prev) => {
 			const next = new Set(prev);
 			if (next.has(id)) {
@@ -154,6 +176,7 @@ export function ChatDrawerPanel({
 	}, [selectedIds, onSendMedia, onBack, t, isExpiring]);
 
 	const hasSelection = selectedIds.size > 0;
+	const hasAlbumSelection = selectedAlbumId !== null;
 
 	const onPickDrawerPhoto = useCallback(
 		(event: React.ChangeEvent<HTMLInputElement>) => {
@@ -441,7 +464,7 @@ export function ChatDrawerPanel({
 									<button
 										type="button"
 										onClick={() => cameraInputRef.current?.click()}
-										disabled={isAdding || hasSelection}
+										disabled={isAdding || hasSelection || hasAlbumSelection}
 										className="relative aspect-square bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:brightness-75"
 										aria-label={t("chat_drawer.take_photo")}
 										title={t("chat_drawer.take_photo")}
@@ -463,7 +486,7 @@ export function ChatDrawerPanel({
 									<button
 										type="button"
 										onClick={() => uploadInputRef.current?.click()}
-										disabled={isAdding || hasSelection}
+										disabled={isAdding || hasSelection || hasAlbumSelection}
 										className="relative aspect-square bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:brightness-75"
 										aria-label={t("chat_drawer.upload_photo")}
 										title={t("chat_drawer.upload_photo")}
@@ -477,6 +500,33 @@ export function ChatDrawerPanel({
 											</span>
 										</div>
 									</button>
+									{/* Albums */}
+									{albums.map((album) => {
+										const cover = albumCoverMap.get(album.albumId);
+										const isShared = sharedAlbumIds.has(album.albumId);
+										const isSelected = selectedAlbumId === album.albumId;
+										const dimmed = hasSelection && !isSelected;
+										return (
+											<div
+												key={`album-${album.albumId}`}
+												role="button"
+												tabIndex={0}
+												onClick={() => { if (!hasSelection) setSelectedAlbumId(isSelected ? null : album.albumId); }}
+												onKeyDown={(e) => e.key === "Enter" && !hasSelection && setSelectedAlbumId(isSelected ? null : album.albumId)}
+												className={`relative aspect-square overflow-hidden cursor-pointer transition ${dimmed ? "opacity-30 pointer-events-none" : ""}`}
+												style={{ outline: isSelected ? "2px solid var(--accent)" : "none", outlineOffset: "-2px" }}
+											>
+												{cover ? <img src={cover} alt={album.albumName ?? ""} className="h-full w-full object-cover" /> : (
+													<div className="absolute inset-0 flex items-center justify-center bg-[var(--surface)] text-[var(--text-muted)]"><Album className="h-6 w-6 opacity-50" /></div>
+												)}
+												<div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 to-transparent px-1.5 py-1">
+													<p className="truncate text-[9px] font-medium text-white leading-tight">{album.albumName || `#${album.albumId}`}</p>
+												</div>
+												{isShared && !isSelected ? <div className="absolute inset-0 flex items-center justify-center bg-black/40"><span className="text-[10px] font-semibold uppercase tracking-widest text-white/90">{t("chat_drawer.sharing", { defaultValue: "Sharing" })}</span></div> : null}
+												{isSelected ? <div className="absolute inset-0 flex items-center justify-center" style={{ background: "color-mix(in srgb, var(--accent) 45%, transparent)" }}><Check className="h-5 w-5 text-white drop-shadow" /></div> : null}
+											</div>
+										);
+									})}
 									{media.map((item) => {
 										const isSelected = selectedIds.has(item.id);
 										const isImage = item.contentType.startsWith("image/");
@@ -486,9 +536,9 @@ export function ChatDrawerPanel({
 												key={item.id}
 												role="button"
 												tabIndex={0}
-												onClick={() => toggleSelection(item.id)}
-												onKeyDown={(e) => e.key === "Enter" && toggleSelection(item.id)}
-												className="relative aspect-square overflow-hidden transition cursor-pointer"
+												onClick={() => { if (!hasAlbumSelection) toggleSelection(item.id); }}
+												onKeyDown={(e) => e.key === "Enter" && !hasAlbumSelection && toggleSelection(item.id)}
+												className={`relative aspect-square overflow-hidden transition cursor-pointer ${hasAlbumSelection ? "opacity-30 pointer-events-none" : ""}`}
 												style={{
 													outline: isSelected ? "2px solid var(--accent)" : "none",
 													outlineOffset: "-2px",
@@ -550,6 +600,55 @@ export function ChatDrawerPanel({
 							)}
 						</div>
 
+						{/* Footer - Album share button */}
+						{hasAlbumSelection ? (() => {
+							const isSelectedShared = selectedAlbumId != null && sharedAlbumIds.has(selectedAlbumId);
+							return (
+								<div className="mt-3 -mx-4 border-t border-[var(--border)] pt-3 px-4 flex gap-2">
+									{isSelectedShared ? (
+										<button
+											type="button"
+											onClick={() => {
+												if (selectedAlbumId == null || !onStopAlbumShare) return;
+												void onStopAlbumShare(selectedAlbumId).then(() => { setSelectedAlbumId(null); onBack(); });
+											}}
+											disabled={isSharingAlbum}
+											className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-orange-500/40 bg-orange-500/10 px-4 text-sm font-semibold text-orange-300 transition hover:bg-orange-500/20 disabled:opacity-60"
+										>
+											{isSharingAlbum ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+											<span>{t("chat.actions.stop_sharing", { defaultValue: "Stop Sharing" })}</span>
+										</button>
+									) : (
+										<>
+											<button
+												type="button"
+												onClick={() => {
+													const idx = EXPIRY_OPTIONS.indexOf(albumExpirationType);
+													setAlbumExpirationType(EXPIRY_OPTIONS[(idx + 1) % EXPIRY_OPTIONS.length]);
+												}}
+												className="inline-flex h-11 min-w-[64px] items-center justify-center gap-1.5 rounded-xl border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+												style={{ flexBasis: "22%" }}
+											>
+												<Hourglass className="h-4 w-4" />
+												<span className="text-sm font-semibold">{EXPIRY_LABELS[albumExpirationType]}</span>
+											</button>
+											<button
+												type="button"
+												onClick={() => {
+													if (selectedAlbumId == null || !onShareAlbum) return;
+													void onShareAlbum(selectedAlbumId, albumExpirationType).then(() => { setSelectedAlbumId(null); onBack(); });
+												}}
+												disabled={isSharingAlbum}
+												className="flex-1 inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+											>
+												{isSharingAlbum ? <Loader2 className="h-4 w-4 animate-spin" /> : <Share2 className="h-4 w-4" />}
+												<span>{isSharingAlbum ? t("chat_drawer.sending") : t("chat.share")}</span>
+											</button>
+										</>
+									)}
+								</div>
+							);
+						})() : null}
 						{/* Footer - Send button */}
 						{hasSelection ? (
 							<div className="mt-3 -mx-4 border-t border-[var(--border)] pt-3 px-4 flex gap-2">

--- a/src/pages/app/chat/ChatDrawerPanel.tsx
+++ b/src/pages/app/chat/ChatDrawerPanel.tsx
@@ -436,13 +436,13 @@ export function ChatDrawerPanel({
 									</button>
 								</div>
 							) : (
-								<div className={`grid gap-0 ${isDesktop ? "grid-cols-5" : "grid-cols-3"}`}>
+								<div className={`grid gap-px bg-[var(--border)] ${isDesktop ? "grid-cols-5" : "grid-cols-3"}`}>
 									{/* Camera button */}
 									<button
 										type="button"
 										onClick={() => cameraInputRef.current?.click()}
-										disabled={isAdding}
-										className="relative aspect-square border-r border-b border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-60"
+										disabled={isAdding || hasSelection}
+										className="relative aspect-square bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:brightness-75"
 										aria-label={t("chat_drawer.take_photo")}
 										title={t("chat_drawer.take_photo")}
 									>
@@ -452,9 +452,9 @@ export function ChatDrawerPanel({
 											) : (
 												<span className="relative inline-flex">
 													<Camera className="h-5 w-5" />
-													<span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+													{!hasSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
 														<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
-													</span>
+													</span>}
 												</span>
 											)}
 										</div>
@@ -463,17 +463,17 @@ export function ChatDrawerPanel({
 									<button
 										type="button"
 										onClick={() => uploadInputRef.current?.click()}
-										disabled={isAdding}
-										className="relative aspect-square border-r border-b border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-60"
+										disabled={isAdding || hasSelection}
+										className="relative aspect-square bg-[var(--surface)] text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:brightness-75"
 										aria-label={t("chat_drawer.upload_photo")}
 										title={t("chat_drawer.upload_photo")}
 									>
 										<div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
 											<span className="relative inline-flex">
 												<Upload className="h-5 w-5" />
-												<span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
-														<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
-													</span>
+												{!hasSelection && <span className="absolute -bottom-1 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--accent)]">
+													<Plus className="h-2.5 w-2.5 stroke-[3] text-[var(--accent-contrast)]" />
+												</span>}
 											</span>
 										</div>
 									</button>
@@ -488,13 +488,10 @@ export function ChatDrawerPanel({
 												tabIndex={0}
 												onClick={() => toggleSelection(item.id)}
 												onKeyDown={(e) => e.key === "Enter" && toggleSelection(item.id)}
-												className="relative aspect-square overflow-hidden border-0 transition cursor-pointer"
+												className="relative aspect-square overflow-hidden transition cursor-pointer"
 												style={{
-													borderColor: isSelected ? "var(--accent)" : "transparent",
-													background: isSelected
-														? "color-mix(in srgb, var(--accent) 16%, var(--surface-2))"
-														: "var(--surface-2)",
-													borderWidth: isSelected ? "2px" : "0px",
+													outline: isSelected ? "2px solid var(--accent)" : "none",
+													outlineOffset: "-2px",
 												}}
 											>
 												{isImage ? (
@@ -510,16 +507,26 @@ export function ChatDrawerPanel({
 													/>
 												)}
 
-												{isSelected ? (
+												{item.used && !isSelected ? (
 													<div className="absolute inset-0 flex items-center justify-center bg-black/40">
-														<Check className="h-4 w-4 text-white" />
+														<span className="text-[11px] font-semibold uppercase tracking-widest text-white/90">
+															{t("chat_drawer.sent", { defaultValue: "Sent" })}
+														</span>
 													</div>
 												) : null}
 
-												{item.used ? (
-													<div className="absolute top-0.5 right-0.5 inline-flex items-center rounded-full bg-black/60 px-1.5 py-0.5 text-[9px] font-semibold text-white">
-														✓
+												{isSelected ? (
+													<div className="absolute inset-0 flex items-center justify-center" style={{ background: "color-mix(in srgb, var(--accent) 45%, transparent)" }}>
+														<Check className="h-5 w-5 text-white drop-shadow" />
 													</div>
+												) : null}
+
+												{item.takenOnGrindr ? (
+													<img
+														src={freegrindLogo}
+														alt=""
+														className="absolute bottom-1 left-1 h-4 w-4 rounded-full logo-shine"
+													/>
 												) : null}
 
 												<button
@@ -545,14 +552,7 @@ export function ChatDrawerPanel({
 
 						{/* Footer - Send button */}
 						{hasSelection ? (
-							<div className="mt-3 -mx-4 border-t border-[var(--border)] pt-3 px-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-								<button
-									type="button"
-									onClick={() => setSelectedIds(new Set())}
-									className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-								>
-									{t("chat.actions.cancel")}
-								</button>
+							<div className="mt-3 -mx-4 border-t border-[var(--border)] pt-3 px-4 flex gap-2">
 								<div className="flex flex-1 gap-2">
 									<button
 										type="button"

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -346,7 +346,8 @@ export function ChatThreadMessages({
 									isAlbumMessage && messageText === t("chat.preview.shared_album");
 								const isLocationOnlyBubble =
 									Boolean(location) && messageText === t("chat.preview.sent_location");
-								const isAudioOnlyBubble =
+								const hasVisualMedia = Boolean(imageUrl) || Boolean(videoUrl) || isAlbumOnlyBubble || isLocationOnlyBubble;
+							const isAudioOnlyBubble =
 									Boolean(audioUrl) && messageText === t("chat.thread.shared_audio");
 								const isMediaOnlyBubble =
 									isImageOnlyBubble || isAlbumOnlyBubble || isLocationOnlyBubble;
@@ -455,12 +456,12 @@ export function ChatThreadMessages({
 																? "bg-[var(--accent)] text-[var(--accent-contrast)] rounded-br-[3px]"
 																: "bg-[var(--surface-2)] text-[var(--text)] rounded-bl-[3px]"
 														}`
-												} ${isActiveSearchMatch ? "ring-2 ring-[var(--accent)]" : ""} ${localOnly ? "opacity-60 ring-1 ring-dashed ring-[var(--text-muted)]" : ""}`}
+												} ${isActiveSearchMatch ? "ring-2 ring-[var(--accent)]" : ""} ${localOnly ? "opacity-50" : ""}`}
 											>
-												{localOnly ? (
-													<p className="mb-1 text-xs opacity-60">
+												{localOnly && !hasVisualMedia ? (
+													<span className="mb-1.5 block w-fit rounded-full bg-black/15 px-2 py-0.5 text-[10px] font-semibold">
 														{t("chat.thread.from_local_history")}
-													</p>
+													</span>
 												) : null}
 												{imageUrl ? (
 													<button
@@ -486,6 +487,11 @@ export function ChatThreadMessages({
 															alt={t("chat.thread.shared_alt")}
 															className={`${isImageOnlyBubble ? "max-h-80 w-full object-cover" : "max-h-64 w-full object-cover"} ${mediaBlurClassName}`}
 														/>
+														{localOnly && (
+															<span className="absolute left-2 top-2 z-10 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-semibold text-white backdrop-blur-sm">
+																{t("chat.thread.from_local_history")}
+															</span>
+														)}
 														{isExpiringImage ? (
 															<div className="absolute right-3 top-3 inline-flex h-6 w-6 items-center justify-center rounded-full bg-black/65 text-xs font-semibold text-white ring-1 ring-white/25">
 																1
@@ -591,6 +597,11 @@ export function ChatThreadMessages({
 															<div className="absolute inset-0 flex items-center justify-center text-[var(--text-muted)]">
 																<Album className="h-8 w-8" />
 															</div>
+															{localOnly && (
+																<span className="absolute left-2 top-2 z-10 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-semibold text-white backdrop-blur-sm">
+																	{t("chat.thread.from_local_history")}
+																</span>
+															)}
 															{albumCover ? (
 																<img
 																	src={albumCover}
@@ -663,7 +674,7 @@ export function ChatThreadMessages({
 
 												{videoUrl ? (
 														<div
-															className="group/media mb-2 overflow-hidden rounded-xl border border-black/10 bg-black"
+															className="group/media relative mb-2 overflow-hidden rounded-xl border border-black/10 bg-black"
 															onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
 															onMouseLeave={() => handleMediaMouseLeave(message.messageId)}
 															onClick={() => {
@@ -672,6 +683,11 @@ export function ChatThreadMessages({
 																}
 															}}
 														>
+														{localOnly && (
+															<span className="absolute left-2 top-2 z-10 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-semibold text-white backdrop-blur-sm">
+																{t("chat.thread.from_local_history")}
+															</span>
+														)}
 														<video
 															controls
 															preload="metadata"
@@ -705,7 +721,14 @@ export function ChatThreadMessages({
 																: "bg-[var(--surface)] text-[var(--text)]"
 														}`}
 													>
-														<LeafletLocationPreview lat={location.lat} lon={location.lon} className="h-32 w-full pointer-events-none" />
+														<div className="relative">
+									<LeafletLocationPreview lat={location.lat} lon={location.lon} className="h-32 w-full pointer-events-none" />
+									{localOnly && (
+										<span className="absolute left-2 top-2 rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-semibold text-white backdrop-blur-sm">
+											{t("chat.thread.from_local_history")}
+										</span>
+									)}
+								</div>
 														<div className="flex items-center gap-3 p-3">
 															<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--accent-contrast)]">
 																<MapPin className="h-4 w-4" />

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -46,7 +46,7 @@ type ChatThreadMessagesProps = {
 	startMessageLongPress: (messageId: string) => void;
 	endMessageLongPress: () => void;
 	messageLongPressTriggeredRef: { current: boolean };
-	openFullScreenImage: (imageUrl: string) => void;
+	openFullScreenImage: (imageUrl: string, meta?: { takenOnGrindr: boolean; createdAtLabel: string | null; timestamp: number }) => void;
 	openAlbumViewerById: (albumId: number) => void | Promise<void>;
 	selectedThreadMessageMatches: Array<{ messageId: string }>;
 	activeThreadSearchIndex: number;
@@ -475,7 +475,11 @@ export function ChatThreadMessages({
 																revealMediaMessage(message.messageId);
 																return;
 															}
-															openFullScreenImage(imageUrl);
+															openFullScreenImage(imageUrl, {
+																	takenOnGrindr: messageTakenOnGrindr,
+																	createdAtLabel: imageCreatedAtLabel,
+																	timestamp: message.timestamp,
+																});
 														}}
 														className={`group/media ${isImageOnlyBubble ? `block w-full overflow-hidden rounded-2xl ${tailCorner}` : "mb-2 block overflow-hidden rounded-xl border border-black/10"}`}
 														onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
@@ -506,11 +510,8 @@ export function ChatThreadMessages({
 																		className="h-3.5 w-3.5 rounded-full"
 																	/>
 																) : null}
-
 																{imageCreatedAtLabel ? (
-																	<span>
-																		{` ${imageCreatedAtLabel}`}
-																	</span>
+																	<span>{` ${imageCreatedAtLabel}`}</span>
 																) : null}
 															</div>
 														) : null}

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -238,6 +238,10 @@ export function ChatThreadMessages({
 		triggered: boolean;
 	} | null>(null);
 
+	const lastTapRef = useRef<{ messageId: string; time: number } | null>(null);
+	const pendingTapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pendingTapActionRef = useRef<(() => void) | null>(null);
+
 	const handleMobileTouchStart = useCallback(
 		(event: React.TouchEvent<HTMLDivElement>, message: UiMessage) => {
 			startMessageLongPress(message.messageId);
@@ -281,6 +285,51 @@ export function ChatThreadMessages({
 		swipeStateRef.current = null;
 		endMessageLongPress();
 	}, [endMessageLongPress]);
+
+	const scheduleMobileTap = useCallback(
+		(message: UiMessage, action: (() => void) | null) => {
+			if (messageLongPressTriggeredRef.current) {
+				messageLongPressTriggeredRef.current = false;
+				return;
+			}
+
+			if (pendingTapTimerRef.current !== null) {
+				clearTimeout(pendingTapTimerRef.current);
+				pendingTapTimerRef.current = null;
+				pendingTapActionRef.current = null;
+			}
+
+			const now = Date.now();
+			const last = lastTapRef.current;
+
+			if (last && last.messageId === message.messageId && now - last.time < 300) {
+				lastTapRef.current = null;
+				void handleReact(message);
+				return;
+			}
+
+			lastTapRef.current = { messageId: message.messageId, time: now };
+
+			if (action) {
+				pendingTapActionRef.current = action;
+				pendingTapTimerRef.current = setTimeout(() => {
+					const act = pendingTapActionRef.current;
+					pendingTapTimerRef.current = null;
+					pendingTapActionRef.current = null;
+					act?.();
+				}, 280);
+			}
+		},
+		[handleReact, messageLongPressTriggeredRef],
+	);
+
+	useEffect(() => {
+		return () => {
+			if (pendingTapTimerRef.current !== null) {
+				clearTimeout(pendingTapTimerRef.current);
+			}
+		};
+	}, []);
 
 	return (
 		<div
@@ -442,7 +491,8 @@ export function ChatThreadMessages({
 									>
 										<div className={`flex flex-col ${mine ? "items-end" : "items-start"} max-w-[85%]`}>
 											<div
-												onDoubleClick={() => void handleMessageTap(message)}
+												onDoubleClick={isDesktop ? () => void handleMessageTap(message) : undefined}
+												onClick={!isDesktop ? () => scheduleMobileTap(message, null) : undefined}
 												onTouchStart={(event) => handleMobileTouchStart(event, message)}
 												onTouchEnd={handleMobileTouchEnd}
 												onTouchCancel={handleMobileTouchEnd}
@@ -466,20 +516,32 @@ export function ChatThreadMessages({
 												{imageUrl ? (
 													<button
 														type="button"
-														onClick={() => {
-															if (messageLongPressTriggeredRef.current) {
-																messageLongPressTriggeredRef.current = false;
-																return;
-															}
-															if (shouldBlurIncomingMedia && !isDesktop) {
-																revealMediaMessage(message.messageId);
-																return;
-															}
-															openFullScreenImage(imageUrl, {
+														onClick={(event) => {
+															event.stopPropagation();
+															if (isDesktop) {
+																openFullScreenImage(imageUrl, {
 																	takenOnGrindr: messageTakenOnGrindr,
 																	createdAtLabel: imageCreatedAtLabel,
 																	timestamp: message.timestamp,
 																});
+																return;
+															}
+															if (messageLongPressTriggeredRef.current) {
+																messageLongPressTriggeredRef.current = false;
+																return;
+															}
+															if (shouldBlurIncomingMedia) {
+																revealMediaMessage(message.messageId);
+																lastTapRef.current = null;
+																return;
+															}
+															scheduleMobileTap(message, () => {
+																openFullScreenImage(imageUrl, {
+																	takenOnGrindr: messageTakenOnGrindr,
+																	createdAtLabel: imageCreatedAtLabel,
+																	timestamp: message.timestamp,
+																});
+															});
 														}}
 														className={`group/media ${isImageOnlyBubble ? `block w-full overflow-hidden rounded-2xl ${tailCorner}` : "mb-2 block overflow-hidden rounded-xl border border-black/10"}`}
 														onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
@@ -576,23 +638,28 @@ export function ChatThreadMessages({
 												{isAlbumOnlyBubble ? (
 													<button
 														type="button"
-														onClick={() => {
-															if (shouldBlurIncomingMedia && !isDesktop) {
-																revealMediaMessage(message.messageId);
+														onClick={(event) => {
+															event.stopPropagation();
+															if (isDesktop) {
+																if (albumId && !isLocked) void openAlbumViewerById(albumId);
 																return;
 															}
 															if (messageLongPressTriggeredRef.current) {
 																messageLongPressTriggeredRef.current = false;
 																return;
 															}
-															if (albumId) {
-																void openAlbumViewerById(albumId);
+															if (shouldBlurIncomingMedia) {
+																revealMediaMessage(message.messageId);
+																lastTapRef.current = null;
+																return;
 															}
+															scheduleMobileTap(message, () => {
+																if (albumId && !isLocked) void openAlbumViewerById(albumId);
+															});
 														}}
 														className={`group/media block w-full overflow-hidden rounded-2xl ${tailCorner}`}
 														onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
 														onMouseLeave={() => handleMediaMouseLeave(message.messageId)}
-														disabled={!albumId || isLocked}
 													>
 														<div className="relative h-56 w-64 max-w-full overflow-hidden bg-[var(--surface-2)] sm:w-72">
 															<div className="absolute inset-0 flex items-center justify-center text-[var(--text-muted)]">
@@ -678,9 +745,11 @@ export function ChatThreadMessages({
 															className="group/media relative mb-2 overflow-hidden rounded-xl border border-black/10 bg-black"
 															onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
 															onMouseLeave={() => handleMediaMouseLeave(message.messageId)}
-															onClick={() => {
+															onClick={(event) => {
+																event.stopPropagation();
 																if (shouldBlurIncomingMedia && !isDesktop) {
 																	revealMediaMessage(message.messageId);
+																	lastTapRef.current = null;
 																}
 															}}
 														>
@@ -699,22 +768,31 @@ export function ChatThreadMessages({
 												) : null}
 
 												{audioUrl ? (
-													<AudioMessagePlayer src={audioUrl} messageId={message.messageId} mine={mine} />
+													<div onClick={(e) => e.stopPropagation()}>
+														<AudioMessagePlayer src={audioUrl} messageId={message.messageId} mine={mine} />
+													</div>
 												) : null}
 
 												{location ? (
 													<button
 														type="button"
-														onClick={async () => {
+														onClick={(event) => {
+															event.stopPropagation();
 															const url = isDesktop
 																? `https://www.google.com/maps/search/?api=1&query=${location.lat},${location.lon}`
 																: `geo:${location.lat},${location.lon}?q=${location.lat},${location.lon}`;
-															try {
-																await openUrl(url);
-															} catch (error) {
-																appLog.error("Failed to open map URL", error);
-																window.open(url, "_blank");
+															const doOpen = () => {
+																openUrl(url).catch((error) => {
+																	appLog.error("Failed to open map URL", error);
+																	window.open(url, "_blank");
+																});
+															};
+															if (isDesktop) { doOpen(); return; }
+															if (messageLongPressTriggeredRef.current) {
+																messageLongPressTriggeredRef.current = false;
+																return;
 															}
+															scheduleMobileTap(message, doOpen);
 														}}
 														className={`mb-2 flex w-full flex-col overflow-hidden rounded-xl border border-black/10 text-left transition hover:brightness-110 ${tailCorner} ${
 															mine
@@ -804,10 +882,9 @@ export function ChatThreadMessages({
 															</span>
 															<button
 																type="button"
-																onClick={() => {
-																	if (albumId) {
-																		void openAlbumViewerById(albumId);
-																	}
+																onClick={(event) => {
+																	event.stopPropagation();
+																	if (albumId) void openAlbumViewerById(albumId);
 																}}
 																className="rounded-md border border-black/20 px-2 py-1 text-[11px]"
 																disabled={!albumId || isLocked}
@@ -832,23 +909,12 @@ export function ChatThreadMessages({
 												) : null}
 
 														{!isLocalClientMessageId(message.messageId) ? (
-													<button
-														type="button"
-														onClick={() => void handleReact(message)}
-														disabled={isMutatingMessageId === message.messageId}
-																className={`${fireButtonClass} z-10 cursor-pointer transition-opacity ${
-															message.reactions.length > 0
-																? "opacity-100"
-																: "opacity-0 group-hover/bubble:opacity-60"
-														} hover:opacity-80`}
-													>
-														<span className={`chat-reaction-flame text-2xl inline-flex ${
-															reactionBurstMessageId === message.messageId ? "chat-reaction-flame--burst" : ""
-														}`}>
-															🔥
-														</span>
-													</button>
-												) : null}
+															<span className={`chat-reaction-flame text-2xl inline-flex pointer-events-none ${fireButtonClass} absolute z-10 transition-opacity ${
+																message.reactions.length > 0 ? "opacity-100" : "opacity-0"
+															} ${reactionBurstMessageId === message.messageId ? "chat-reaction-flame--burst" : ""}`}>
+																🔥
+															</span>
+														) : null}
 
 												{!isMediaOnlyBubble ? (
 												<div className="mt-1 flex items-center justify-between gap-2 text-[10px] opacity-80">
@@ -994,7 +1060,7 @@ export function ChatThreadMessages({
 												{failed ? (
 													<button
 														type="button"
-														onClick={() => handleRetry(message)}
+														onClick={(event) => { event.stopPropagation(); handleRetry(message); }}
 														className="mt-1 rounded-lg bg-[color-mix(in_srgb,var(--surface)_72%,transparent)] px-2 py-1 text-[11px] font-semibold"
 													>
 														{t("chat.retry")}

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -60,7 +60,6 @@ type ChatThreadMessagesProps = {
 	handleRetry: (message: Message) => void;
 	handleReply: (message: Message) => void | Promise<void>;
 	handleStopAlbumShare: (albumId: number) => void | Promise<void>;
-	albumCoverMap: Map<number, string>;
 	threadBottomRef: { current: HTMLDivElement | null };
 };
 
@@ -148,7 +147,6 @@ export function ChatThreadMessages({
 	handleRetry,
 	handleReply,
 	handleStopAlbumShare,
-	albumCoverMap,
 	threadBottomRef,
 }: ChatThreadMessagesProps) {
 	const { t } = useTranslation();
@@ -231,15 +229,6 @@ export function ChatThreadMessages({
 		for (const m of threadMessages) {
 			const aid = getMessageAlbumId(m);
 			if (aid) map.set(aid, m.messageId);
-		}
-		return map;
-	}, [threadMessages]);
-
-	const latestShareViewableByAlbum = useMemo(() => {
-		const map = new Map<number, boolean>();
-		for (const m of threadMessages) {
-			const aid = getMessageAlbumId(m);
-			if (aid) map.set(aid, (m.body as any)?.isViewable === true);
 		}
 		return map;
 	}, [threadMessages]);
@@ -395,7 +384,7 @@ export function ChatThreadMessages({
 								const audioUrl = getMessageAudioUrl(message);
 								const location = getMessageLocation(message);
 								const albumId = getMessageAlbumId(message);
-								const albumCover = (albumId ? albumCoverMap.get(albumId) : null) ?? getMessageAlbumCoverUrl(message);
+								const albumCover = getMessageAlbumCoverUrl(message);
 								const messageText = getMessageText(message, t);
 								const isExpiringImage = message.type === "ExpiringImage";
 								const isAlbumMessage =
@@ -474,9 +463,7 @@ export function ChatThreadMessages({
 								// ownerProfileId is null when expired/locked, but isViewable is more reliable
 								// (e.g. sender may lock the album while ownerProfileId is still present).
 								// My own sent albums are never locked from my perspective.
-								// If the latest share of an album is viewable, all older shares unlock too.
-								const albumCurrentlyViewable = albumId ? latestShareViewableByAlbum.get(albumId) === true : false;
-								const isLocked = isAlbumMessage && !albumCurrentlyViewable;
+								const isLocked = isAlbumMessage && (!isLatestShare || !msgBody?.isViewable);
 
 								return (
 								/* Use Fragment to allow rendering the separator and the message as a single map item */

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -60,6 +60,7 @@ type ChatThreadMessagesProps = {
 	handleRetry: (message: Message) => void;
 	handleReply: (message: Message) => void | Promise<void>;
 	handleStopAlbumShare: (albumId: number) => void | Promise<void>;
+	albumCoverMap: Map<number, string>;
 	threadBottomRef: { current: HTMLDivElement | null };
 };
 
@@ -147,6 +148,7 @@ export function ChatThreadMessages({
 	handleRetry,
 	handleReply,
 	handleStopAlbumShare,
+	albumCoverMap,
 	threadBottomRef,
 }: ChatThreadMessagesProps) {
 	const { t } = useTranslation();
@@ -229,6 +231,15 @@ export function ChatThreadMessages({
 		for (const m of threadMessages) {
 			const aid = getMessageAlbumId(m);
 			if (aid) map.set(aid, m.messageId);
+		}
+		return map;
+	}, [threadMessages]);
+
+	const latestShareViewableByAlbum = useMemo(() => {
+		const map = new Map<number, boolean>();
+		for (const m of threadMessages) {
+			const aid = getMessageAlbumId(m);
+			if (aid) map.set(aid, (m.body as any)?.isViewable === true);
 		}
 		return map;
 	}, [threadMessages]);
@@ -384,7 +395,7 @@ export function ChatThreadMessages({
 								const audioUrl = getMessageAudioUrl(message);
 								const location = getMessageLocation(message);
 								const albumId = getMessageAlbumId(message);
-								const albumCover = getMessageAlbumCoverUrl(message);
+								const albumCover = (albumId ? albumCoverMap.get(albumId) : null) ?? getMessageAlbumCoverUrl(message);
 								const messageText = getMessageText(message, t);
 								const isExpiringImage = message.type === "ExpiringImage";
 								const isAlbumMessage =
@@ -463,7 +474,9 @@ export function ChatThreadMessages({
 								// ownerProfileId is null when expired/locked, but isViewable is more reliable
 								// (e.g. sender may lock the album while ownerProfileId is still present).
 								// My own sent albums are never locked from my perspective.
-								const isLocked = isAlbumMessage && (!isLatestShare || !msgBody?.isViewable);
+								// If the latest share of an album is viewable, all older shares unlock too.
+								const albumCurrentlyViewable = albumId ? latestShareViewableByAlbum.get(albumId) === true : false;
+								const isLocked = isAlbumMessage && !albumCurrentlyViewable;
 
 								return (
 								/* Use Fragment to allow rendering the separator and the message as a single map item */

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -719,7 +719,7 @@ export function ChatThreadMessages({
 														className={`mb-2 flex w-full flex-col overflow-hidden rounded-xl border border-black/10 text-left transition hover:brightness-110 ${tailCorner} ${
 															mine
 																? "bg-white/10 text-white"
-																: "bg-[var(--surface)] text-[var(--text)]"
+																: "bg-[var(--surface-2)] text-[var(--text)]"
 														}`}
 													>
 														<div className="relative">

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -59,6 +59,7 @@ type ChatThreadMessagesProps = {
 	handleDelete: (message: Message) => void | Promise<void>;
 	handleRetry: (message: Message) => void;
 	handleReply: (message: Message) => void | Promise<void>;
+	handleStopAlbumShare: (albumId: number) => void | Promise<void>;
 	threadBottomRef: { current: HTMLDivElement | null };
 };
 
@@ -145,6 +146,7 @@ export function ChatThreadMessages({
 	handleDelete,
 	handleRetry,
 	handleReply,
+	handleStopAlbumShare,
 	threadBottomRef,
 }: ChatThreadMessagesProps) {
 	const { t } = useTranslation();
@@ -461,7 +463,7 @@ export function ChatThreadMessages({
 								// ownerProfileId is null when expired/locked, but isViewable is more reliable
 								// (e.g. sender may lock the album while ownerProfileId is still present).
 								// My own sent albums are never locked from my perspective.
-								const isLocked = isAlbumMessage && (!isLatestShare || !msgBody?.isViewable) && message.senderId !== userId;
+								const isLocked = isAlbumMessage && (!isLatestShare || !msgBody?.isViewable);
 
 								return (
 								/* Use Fragment to allow rendering the separator and the message as a single map item */
@@ -1044,6 +1046,16 @@ export function ChatThreadMessages({
 																className="rounded-md border border-black/20 px-2 py-1"
 															>
 																{t("chat.actions.unsend")}
+															</button>
+														) : null}
+														{mine && isAlbumMessage && albumId && (message.body as any)?.isViewable ? (
+															<button
+																type="button"
+																onClick={() => void handleStopAlbumShare(albumId)}
+																disabled={isMutatingMessageId === message.messageId}
+																className="rounded-md border border-orange-500/40 bg-orange-500/10 px-2 py-1 text-orange-400 transition hover:bg-orange-500/20"
+															>
+																{t("chat.actions.stop_sharing", { defaultValue: "Stop Sharing" })}
 															</button>
 														) : null}
 														<button

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -1,4 +1,6 @@
 import { Album, Ellipsis, Hourglass, Lock, MapPin, Reply } from "lucide-react";
+import { LeafletLocationPreview } from "../gridpage/components/LeafletLocationPreview";
+import { AudioMessagePlayer } from "./AudioMessagePlayer";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Fragment, useEffect, useState, useMemo, useCallback, useRef } from "react";
 
@@ -344,8 +346,11 @@ export function ChatThreadMessages({
 									isAlbumMessage && messageText === t("chat.preview.shared_album");
 								const isLocationOnlyBubble =
 									Boolean(location) && messageText === t("chat.preview.sent_location");
+								const isAudioOnlyBubble =
+									Boolean(audioUrl) && messageText === t("chat.thread.shared_audio");
 								const isMediaOnlyBubble =
 									isImageOnlyBubble || isAlbumOnlyBubble || isLocationOnlyBubble;
+								const tailCorner = mine ? "rounded-br-[3px]" : "rounded-bl-[3px]";
 								const shouldBlurIncomingMedia =
 									blurIncomingMedia &&
 									!mine &&
@@ -447,8 +452,8 @@ export function ChatThreadMessages({
 														? "bg-transparent p-0"
 														: `px-3 py-2 ${
 															mine
-																? "bg-[var(--accent)] text-[var(--accent-contrast)]"
-																: "bg-[var(--surface-2)] text-[var(--text)]"
+																? "bg-[var(--accent)] text-[var(--accent-contrast)] rounded-br-[3px]"
+																: "bg-[var(--surface-2)] text-[var(--text)] rounded-bl-[3px]"
 														}`
 												} ${isActiveSearchMatch ? "ring-2 ring-[var(--accent)]" : ""} ${localOnly ? "opacity-60 ring-1 ring-dashed ring-[var(--text-muted)]" : ""}`}
 											>
@@ -471,7 +476,7 @@ export function ChatThreadMessages({
 															}
 															openFullScreenImage(imageUrl);
 														}}
-														className={`group/media ${isImageOnlyBubble ? "block w-full overflow-hidden rounded-2xl" : "mb-2 block overflow-hidden rounded-xl border border-black/10"}`}
+														className={`group/media ${isImageOnlyBubble ? `block w-full overflow-hidden rounded-2xl ${tailCorner}` : "mb-2 block overflow-hidden rounded-xl border border-black/10"}`}
 														onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
 														onMouseLeave={() => handleMediaMouseLeave(message.messageId)}
 													>
@@ -577,7 +582,7 @@ export function ChatThreadMessages({
 																void openAlbumViewerById(albumId);
 															}
 														}}
-														className="group/media block w-full overflow-hidden rounded-2xl"
+														className={`group/media block w-full overflow-hidden rounded-2xl ${tailCorner}`}
 														onMouseEnter={() => handleMediaMouseEnter(message.messageId)}
 														onMouseLeave={() => handleMediaMouseLeave(message.messageId)}
 														disabled={!albumId || isLocked}
@@ -677,14 +682,7 @@ export function ChatThreadMessages({
 												) : null}
 
 												{audioUrl ? (
-													<div className="mb-2 rounded-xl border border-black/10 bg-[color-mix(in_srgb,var(--surface)_76%,transparent)] p-2">
-														<audio
-															controls
-															preload="none"
-															src={audioUrl}
-															className="w-full"
-														/>
-													</div>
+													<AudioMessagePlayer src={audioUrl} messageId={message.messageId} mine={mine} />
 												) : null}
 
 												{location ? (
@@ -701,15 +699,16 @@ export function ChatThreadMessages({
 																window.open(url, "_blank");
 															}
 														}}
-														className={`mb-2 flex w-full flex-col gap-2 rounded-xl border border-black/10 p-3 text-left transition hover:brightness-110 ${
+														className={`mb-2 flex w-full flex-col overflow-hidden rounded-xl border border-black/10 text-left transition hover:brightness-110 ${tailCorner} ${
 															mine
 																? "bg-white/10 text-white"
 																: "bg-[var(--surface)] text-[var(--text)]"
 														}`}
 													>
-														<div className="flex items-center gap-3">
-															<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--accent-contrast)] shadow-sm">
-																<MapPin className="h-5 w-5" />
+														<LeafletLocationPreview lat={location.lat} lon={location.lon} className="h-32 w-full pointer-events-none" />
+														<div className="flex items-center gap-3 p-3">
+															<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--accent-contrast)]">
+																<MapPin className="h-4 w-4" />
 															</div>
 															<div className="min-w-0 flex-1">
 																<p className="text-[10px] font-bold uppercase tracking-wider opacity-70">
@@ -722,14 +721,11 @@ export function ChatThreadMessages({
 														</div>
 
 														{isLocationOnlyBubble && (
-															<div className="flex items-center justify-between gap-2 border-t border-black/5 pt-2 text-[10px] opacity-80">
-																<span>
-																	{formatMessageTime(message.timestamp, nowTimestamp, t)}
-																</span>
+															<div className="flex items-center justify-end gap-2 px-3 pb-2 text-[10px] opacity-80">
 																{isDesktop &&
 																!pending &&
 																!isLocalClientMessageId(message.messageId) ? (
-																	<div className="flex items-center gap-1">
+																	<>
 																		<button
 																			type="button"
 																			onClick={(event) => {
@@ -754,8 +750,11 @@ export function ChatThreadMessages({
 																		>
 																			<Ellipsis className="h-3.5 w-3.5" />
 																		</button>
-																	</div>
+																	</>
 																) : null}
+																<span>
+																	{formatMessageTime(message.timestamp, nowTimestamp, t)}
+																</span>
 															</div>
 														)}
 													</button>
@@ -802,7 +801,7 @@ export function ChatThreadMessages({
 													</div>
 												) : null}
 
-												{!isMediaOnlyBubble ? (
+												{!isMediaOnlyBubble && !isAudioOnlyBubble ? (
 													<p className="whitespace-pre-wrap break-words">
 														{messageText}
 													</p>

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1853,31 +1853,40 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                 }
             >
 				{(isUploadingAttachment || uploadProgress > 0) && (
-					<div className="absolute top-0 left-0 right-0 h-0.5 bg-[var(--surface-2)]">
+					<div
+						className="h-0.5 bg-[var(--surface-2)] mb-3"
+						style={{ marginTop: "-12px", marginLeft: "calc(-1 * var(--app-px))", marginRight: "calc(-1 * var(--app-px))" }}
+					>
 						<div
 							className="h-0.5 bg-[var(--accent)] transition-all duration-300"
 							style={{ width: `${Math.min(100, uploadProgress)}%` }}
 						/>
 					</div>
 				)}
-                <div className="flex items-end gap-2 mb-2">
-                    {/* --- QUICK PHRASE PILLS --- */}
-                    {filteredPhrases.length > 0 && (
-                        <div className="flex flex-1 items-center gap-2 overflow-x-auto pb-1 -mb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                            {filteredPhrases.map((phrase, idx) => (
-                                <button
-                                    key={idx}
-                                    type="button"
-                                    onClick={() => handleUsePhrase(phrase)}
-                                    className="shrink-0 whitespace-nowrap rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)] active:scale-95"
-                                >
-                                    {phrase}
-                                </button>
-                            ))}
-                        </div>
-                    )}
-                    {/* -------------------------- */}
-                </div>
+				{/* --- QUICK PHRASE PILLS --- */}
+				{filteredPhrases.length > 0 && (
+					<div className="mb-2 flex items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+						{filteredPhrases.map((phrase, idx) => {
+							const isExact = phrase.toLowerCase() === draft.trim().toLowerCase();
+							return (
+								<button
+									key={idx}
+									type="button"
+									onClick={() => handleUsePhrase(phrase)}
+									className={`shrink-0 whitespace-nowrap rounded-2xl rounded-br-[3px] border px-3 py-1.5 text-xs font-medium transition active:scale-95 ${
+										isExact
+											? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
+											: "border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
+									}`}
+								>
+									{phrase}
+								</button>
+							);
+						})}
+					</div>
+				)}
+				{/* -------------------------- */}
+
                 <div className="flex items-end gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-1.5 mb-2 focus-within:border-[var(--accent)] transition-colors">
 					<textarea
 						value={draft}
@@ -1891,7 +1900,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					<button
 						type="submit"
 						disabled={isSending || !!pendingLocationShare || draft.trim().length === 0}
-						className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-sm bg-[var(--accent)] text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-40"
+						className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--accent)] transition hover:opacity-80 disabled:opacity-30"
 					>
 						{isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SendHorizontal className="h-4 w-4" />}
 					</button>
@@ -1948,8 +1957,8 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                     </button>
                     <button
                         type="button"
-                        onClick={() => navigate("/settings/saved-phrases")}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+                        onClick={() => setIsSavedPhrasesOpen((prev) => !prev)}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:text-[var(--text)]"
                         aria-label={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
                         title={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
                     >
@@ -2015,7 +2024,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					confirmLabel={t("chat.attachments.send_attachment")}
 					cancelLabel={t("chat.actions.cancel")}
 					isProcessing={isUploadingAttachment}
-					isDesktop={true}
+					isDesktop={isDesktop}
 				>
 					{attachmentPreviewUrl && (
 						pendingAttachmentFile.type.startsWith("video/") ? (
@@ -2102,8 +2111,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						setPendingLocationShare(null);
 					}}
 					confirmLabel={t("chat.send")}
-					cancelLabel={t("chat.actions.cancel")}
-					isDesktop={true}
+					isDesktop={isDesktop}
 				>
 					<div className="px-3 pb-3">
 						<div className="overflow-hidden rounded-xl border border-[var(--border)]" style={{ height: "40dvh" }}>
@@ -2196,6 +2204,62 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                         </div>
                 </BottomSheet>
             ) : null}
+
+			{isSavedPhrasesOpen ? (
+				<BottomSheet
+					onClose={() => { setPhrasesExpanded(false); setIsSavedPhrasesOpen(false); }}
+					onExpand={() => setPhrasesExpanded(true)}
+					isDesktop={isDesktop}
+					bg="bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)]"
+				>
+					<div className="flex items-center justify-between px-4 pb-3">
+						<div className="flex items-center gap-2">
+							<p className="text-sm font-semibold text-[var(--text)]">{t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}</p>
+							{savedPhrases.length > 0 && (
+								<span className="rounded-full bg-[var(--surface-2)] px-2 py-0.5 text-[11px] font-semibold tabular-nums text-[var(--text-muted)]">{savedPhrases.length}</span>
+							)}
+						</div>
+						<div className="flex items-center gap-1">
+							<button type="button" onClick={() => { setIsSavedPhrasesOpen(false); navigate("/settings/saved-phrases"); }} className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]" aria-label={t("chat.saved_phrases_manage", { defaultValue: "Manage" })}>
+								<Settings2 className="h-4 w-4" />
+							</button>
+							<SheetClose className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]">
+								<X className="h-4 w-4" />
+							</SheetClose>
+						</div>
+					</div>
+					<div className="px-3 pb-3">
+						<div className="flex gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-1.5">
+							<input type="text" value={newPhraseInput} onChange={(e) => setNewPhraseInput(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAddPhrase(); } }} placeholder={t("settings_saved_phrases.new_placeholder", { defaultValue: "Add a new phrase..." })} className="min-w-0 flex-1 bg-transparent px-2 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none" />
+							<button type="button" onClick={handleAddPhrase} disabled={!newPhraseInput.trim()} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-[var(--accent)] px-3 text-xs font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-40">
+								<Plus className="h-3.5 w-3.5" />
+								{t("settings_saved_phrases.add", { defaultValue: "Add" })}
+							</button>
+						</div>
+					</div>
+					<div className="border-t border-[var(--border)]" />
+					<div data-lenis-prevent className="overflow-y-auto" style={{ maxHeight: phrasesExpanded ? "72dvh" : "40dvh", transition: "max-height 0.25s ease" }}>
+						{savedPhrases.length === 0 ? (
+							<div className="flex flex-col items-center gap-2.5 py-8 text-[var(--text-muted)]">
+								<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--surface-2)]"><BookMarked className="h-5 w-5 opacity-60" /></div>
+								<p className="text-sm font-medium">{t("settings_saved_phrases.empty", { defaultValue: "No saved phrases yet." })}</p>
+								<p className="text-xs opacity-60">{t("settings_saved_phrases.empty_hint", { defaultValue: "Type above to add your first phrase." })}</p>
+							</div>
+						) : (
+							<div>
+								{savedPhrases.map((phrase, originalIndex) => (
+									<div key={originalIndex} className="group flex items-center px-4">
+										<div className="flex flex-1 items-center gap-1 py-3">
+											<SheetClose onClick={() => handleUsePhrase(phrase)} className="min-w-0 flex-1 text-left text-sm text-[var(--text)] transition hover:text-[var(--accent)]">{phrase}</SheetClose>
+											<button type="button" onClick={() => handleDeletePhrase(originalIndex)} className="shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-red-400" aria-label={t("settings_saved_phrases.delete", { defaultValue: "Delete phrase" })}><Trash2 className="h-3.5 w-3.5" /></button>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				</BottomSheet>
+			) : null}
 		</div>
 	) : (
 		<div

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1169,6 +1169,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						handleRetry={handleRetry}
 						handleReply={handleReply}
 						handleStopAlbumShare={handleStopAlbumShare}
+						albumCoverMap={albumCoverMap}
 						threadBottomRef={threadBottomRef}
 				/>
 				)

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1458,8 +1458,8 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					{isSavedPhrasesOpen ? (
 						<BottomSheet
 							onClose={() => {
-								if (phrasesExpanded) setPhrasesExpanded(false);
-								else setIsSavedPhrasesOpen(false);
+								setPhrasesExpanded(false);
+								setIsSavedPhrasesOpen(false);
 							}}
 							onExpand={() => setPhrasesExpanded(true)}
 							isDesktop={isDesktop}

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -11,6 +11,8 @@ import {
 	Infinity,
 	Loader2,
 	MapPin,
+	Plus,
+	Settings2,
 	BookMarked,
 	MessageCircleOff,
 	MessageCircleX,
@@ -67,6 +69,8 @@ import { ToggleRow } from "../../../components/ui/toggle-row";
 import { BottomDrawer } from "../../../components/ui/bottom-drawer";
 import {
 	loadSavedPhrases,
+	saveSavedPhrases,
+
 	SAVED_PHRASES_UPDATED_EVENT,
 } from "../../../services/savedPhrases";
 
@@ -183,6 +187,9 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 	const { unitsPreset, geohash } = usePreferences();
 	const [selectedExpirationType, setSelectedExpirationType] = useState("INDEFINITE");
 	const [pendingLocationShare, setPendingLocationShare] = useState<{ lat: number; lon: number } | null>(null);
+	const [isSavedPhrasesOpen, setIsSavedPhrasesOpen] = useState(false);
+	const [newPhraseInput, setNewPhraseInput] = useState("");
+
 	const [attachmentPreviewUrl, setAttachmentPreviewUrl] = useState<string | null>(null);
 	const [attachmentCrop, setAttachmentCrop] = useState<Crop | undefined>(undefined);
 	const [attachmentCompletedCrop, setAttachmentCompletedCrop] = useState<PixelCrop | undefined>(undefined);
@@ -393,6 +400,20 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		setDraft(draft ? `${draft} ${phrase}` : phrase);
 	};
 
+	const handleAddPhrase = () => {
+		const trimmed = newPhraseInput.trim();
+		if (!trimmed) return;
+		const updated = saveSavedPhrases([...savedPhrases, trimmed]);
+		setSavedPhrases(updated);
+		setNewPhraseInput("");
+	};
+
+	const handleDeletePhrase = (index: number) => {
+		const updated = saveSavedPhrases(savedPhrases.filter((_, i) => i !== index));
+		setSavedPhrases(updated);
+	};
+
+
 	useEffect(() => {
 		const syncSavedPhrases = (event: Event) => {
 			const detail = (event as CustomEvent<string[]>).detail;
@@ -506,6 +527,11 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		isOpen: isDeleteConversationConfirmOpen,
 		onClose: closeDeleteConversationConfirm,
 		escapeKey: !isDeletingConversation,
+	});
+
+	useModalClose({
+		isOpen: isSavedPhrasesOpen,
+		onClose: () => setIsSavedPhrasesOpen(false),
 	});
 
 	useEffect(() => {
@@ -1164,22 +1190,22 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							</div>
 						) : null}
 
-						<div className="flex items-end gap-2 mb-2">
+						<div className="flex items-end gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-1.5 mb-2 focus-within:border-[var(--accent)] transition-colors">
 							<textarea
 								value={draft}
 								onChange={(event) => setDraft(event.target.value)}
 								rows={1}
 								maxLength={1000}
 								placeholder={t("chat.write_message")}
-								className="input-field resize-none disabled:opacity-60"
+								className="flex-1 bg-transparent py-1 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none resize-none disabled:opacity-60"
                                 style={{ fieldSizing: "content", maxHeight: "115px" }}
 							/>
 							<button
 								type="submit"
 								disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
-								className="btn-accent self-stretch shrink-0 px-4 text-sm"
+								className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--accent)] transition hover:opacity-80 disabled:opacity-30"
 							>
-								<SendHorizontal className="h-4 w-4" />
+								{isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SendHorizontal className="h-4 w-4" />}
 							</button>
 						</div>
 
@@ -1245,8 +1271,8 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							</button>
 							<button
 								type="button"
-								onClick={() => navigate("/settings/saved-phrases")}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+								onClick={() => setIsSavedPhrasesOpen((prev) => !prev)}
+								className={`inline-flex h-9 w-9 items-center justify-center rounded-xl transition ${isSavedPhrasesOpen ? "bg-[var(--accent)] text-[var(--accent-contrast)]" : "text-[var(--text-muted)] hover:text-[var(--text)]"}`}
 								aria-label={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
 								title={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
 							>
@@ -1432,6 +1458,123 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							</div>
 						</BottomDrawer>
                     ) : null}
+
+					{isSavedPhrasesOpen ? (
+						<div
+							className="fixed inset-0 z-[60] flex items-end bg-black/45 backdrop-blur-sm no-touch-callout"
+							onClick={() => setIsSavedPhrasesOpen(false)}
+						>
+							<div
+								role="dialog"
+								aria-modal="true"
+								className={`flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"}`}
+								style={{ paddingBottom: "max(16px, env(safe-area-inset-bottom))" }}
+								onClick={(e) => e.stopPropagation()}
+							>
+								{/* Header */}
+								<div className="flex items-center justify-between px-4 pt-4 pb-3">
+									<div className="flex items-center gap-2">
+										<p className="text-sm font-semibold text-[var(--text)]">
+											{t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
+										</p>
+										{savedPhrases.length > 0 && (
+											<span className="rounded-full bg-[var(--surface-2)] px-2 py-0.5 text-[11px] font-semibold tabular-nums text-[var(--text-muted)]">
+												{savedPhrases.length}
+											</span>
+										)}
+									</div>
+									<div className="flex items-center gap-1">
+										<button
+											type="button"
+											onClick={() => { setIsSavedPhrasesOpen(false); navigate("/settings/saved-phrases"); }}
+											className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
+											aria-label={t("chat.saved_phrases_manage", { defaultValue: "Manage" })}
+											title={t("chat.saved_phrases_manage", { defaultValue: "Manage" })}
+										>
+											<Settings2 className="h-4 w-4" />
+										</button>
+										<button
+											type="button"
+											onClick={() => setIsSavedPhrasesOpen(false)}
+											className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
+										>
+											<X className="h-4 w-4" />
+										</button>
+									</div>
+								</div>
+
+								{/* Add input */}
+								<div className="px-3 pb-3">
+									<div className="flex gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-1.5">
+										<input
+											type="text"
+											value={newPhraseInput}
+											onChange={(e) => setNewPhraseInput(e.target.value)}
+											onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAddPhrase(); } }}
+											placeholder={t("settings_saved_phrases.new_placeholder", { defaultValue: "Add a new phrase..." })}
+											className="min-w-0 flex-1 bg-transparent px-2 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none"
+										/>
+										<button
+											type="button"
+											onClick={handleAddPhrase}
+											disabled={!newPhraseInput.trim()}
+											className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-[var(--accent)] px-3 text-xs font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-40"
+										>
+											<Plus className="h-3.5 w-3.5" />
+											{t("settings_saved_phrases.add", { defaultValue: "Add" })}
+										</button>
+									</div>
+								</div>
+
+								<div className="border-t border-[var(--border)]" />
+
+								{/* Phrases list */}
+								<div data-lenis-prevent className="overflow-y-auto max-h-[40dvh] p-3">
+									{savedPhrases.length === 0 ? (
+										<div className="flex flex-col items-center gap-2.5 py-8 text-[var(--text-muted)]">
+											<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--surface-2)]">
+												<BookMarked className="h-5 w-5 opacity-60" />
+											</div>
+											<p className="text-sm font-medium">
+												{t("settings_saved_phrases.empty", { defaultValue: "No saved phrases yet." })}
+											</p>
+											<p className="text-xs opacity-60">
+												{t("settings_saved_phrases.empty_hint", { defaultValue: "Type above to add your first phrase." })}
+											</p>
+										</div>
+									) : (
+										<div className="grid gap-1">
+											{savedPhrases.map((phrase, originalIndex) => (
+												<div
+													key={originalIndex}
+													className="flex items-center rounded-xl transition hover:bg-[var(--surface-2)]"
+												>
+													<button
+														type="button"
+														onClick={() => {
+															handleUsePhrase(phrase);
+															setIsSavedPhrasesOpen(false);
+														}}
+														className="min-w-0 flex-1 px-3 py-2.5 text-left text-sm text-[var(--text)]"
+													>
+														{phrase}
+													</button>
+													<button
+														type="button"
+														onClick={() => handleDeletePhrase(originalIndex)}
+														className="mr-1.5 shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-red-400"
+														aria-label={t("settings_saved_phrases.delete", { defaultValue: "Delete phrase" })}
+													>
+														<Trash2 className="h-3.5 w-3.5" />
+													</button>
+												</div>
+											))}
+										</div>
+									)}
+								</div>
+							</div>
+						</div>
+					) : null}
 
 					{!isDesktop && selectedActionMessage && albumViewer === null ? (
 						<div
@@ -1761,22 +1904,22 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                     )}
                     {/* -------------------------- */}
                 </div>
-                <div className="flex items-end gap-2 mb-2">
+                <div className="flex items-end gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-1.5 mb-2 focus-within:border-[var(--accent)] transition-colors">
 					<textarea
 						value={draft}
 						onChange={(event) => setDraft(event.target.value)}
 						rows={1}
 						maxLength={1000}
 						placeholder={t("chat.new_conversation.write_first_message")}
-						className="input-field resize-none disabled:opacity-60"
+						className="flex-1 bg-transparent py-1 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none resize-none disabled:opacity-60"
                         style={{ fieldSizing: "content", maxHeight: "115px" }}
 					/>
 					<button
 						type="submit"
 						disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
-						className="btn-accent self-stretch shrink-0 px-4 text-sm"
+						className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-sm bg-[var(--accent)] text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-40"
 					>
-						{isSending ? t("chat.sending") : t("chat.send")}
+						{isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SendHorizontal className="h-4 w-4" />}
 					</button>
 				</div>
 

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1144,7 +1144,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 											key={idx}
 											type="button"
 											onClick={() => handleUsePhrase(phrase)}
-											className={`shrink-0 whitespace-nowrap rounded-2xl rounded-bl-[3px] border px-3 py-1.5 text-xs font-medium transition active:scale-95 ${
+											className={`shrink-0 whitespace-nowrap rounded-2xl rounded-br-[3px] border px-3 py-1.5 text-xs font-medium transition active:scale-95 ${
 												isExact
 													? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
 													: "border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)]"

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1,6 +1,6 @@
 import {
+	Album,
 	Ban,
-	ChevronDown,
 	ChevronLeft,
 	Ellipsis,
     Eye,
@@ -31,7 +31,7 @@ import {
 	X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactCrop, { type Crop, type PixelCrop } from "react-image-crop";
 import "react-image-crop/dist/ReactCrop.css";
 import type { NavigateFunction } from "react-router-dom";
@@ -57,6 +57,8 @@ import {
 	getMessageImageUrl,
 	getMessageVideoUrl,
 	getMessageAudioUrl,
+	getMessageAlbumId,
+	getMessageAlbumCoverUrl,
 } from "./chatUtils";
 import { formatDistance } from "../gridpage/utils";
 import { ProfileImage } from "../../../components/ui/profile-image";
@@ -127,6 +129,7 @@ type ChatThreadPanelProps = {
 	handleDelete: (message: Message) => void | Promise<void>;
 	handleRetry: (message: Message) => void;
 	handleReply: (message: Message) => void | Promise<void>;
+	handleStopAlbumShare: (albumId: number) => void | Promise<void>;
 	threadBottomRef: { current: HTMLDivElement | null };
 	handleSend: (event: React.FormEvent<HTMLFormElement>) => void;
 	toggleAlbumPicker: () => void;
@@ -167,6 +170,8 @@ type ChatThreadPanelProps = {
 	onSendDrawerMedia: (mediaIds: number[], isExpiring?: boolean) => Promise<void>;
 	onAddDrawerMedia: (file: File, takenOnGrindr: boolean) => Promise<void>;
 	onDeleteDrawerMedia: (mediaId: number) => Promise<void>;
+	onShareAlbumFromDrawer: (albumId: number, expirationType: string) => Promise<void>;
+	onStopAlbumShareFromDrawer: (albumId: number) => Promise<void>;
 	onSendLocation: (lat: number, lon: number) => void | Promise<void>;
 	uploadProgress: number;
 	draft: string;
@@ -262,6 +267,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		handleDelete,
 		handleRetry,
 		handleReply,
+		handleStopAlbumShare,
 		threadBottomRef,
 		handleSend,
 		toggleAlbumPicker,
@@ -306,6 +312,8 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		onSendDrawerMedia,
 		onAddDrawerMedia,
 		onDeleteDrawerMedia,
+		onShareAlbumFromDrawer,
+		onStopAlbumShareFromDrawer,
 		onSendLocation,
 	} = props;
 
@@ -439,6 +447,26 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
     const filteredPhrases = savedPhrases.filter((phrase) =>
         draft.trim() === "" || phrase.toLowerCase().startsWith(draft.toLowerCase()),
     );
+
+	const albumCoverMap = useMemo(() => {
+		const map = new Map<number, string>();
+		for (const msg of threadMessages) {
+			const aid = getMessageAlbumId(msg);
+			const cover = getMessageAlbumCoverUrl(msg);
+			if (aid && cover) map.set(aid, cover);
+		}
+		return map;
+	}, [threadMessages]);
+
+	const sharedAlbumIds = useMemo(() => {
+		const ids = new Set<number>();
+		for (const msg of threadMessages) {
+			const aid = getMessageAlbumId(msg);
+			const body = msg.body as any;
+			if (aid && body?.isViewable) ids.add(aid);
+		}
+		return ids;
+	}, [threadMessages]);
 
     const [showGhostButton] = useState(() => window.localStorage.getItem("fg-show-ghost-btn") !== "false");
     const [isGhosted, setIsGhosted] = useState(true);
@@ -1140,6 +1168,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						handleDelete={handleDelete}
 						handleRetry={handleRetry}
 						handleReply={handleReply}
+						handleStopAlbumShare={handleStopAlbumShare}
 						threadBottomRef={threadBottomRef}
 				/>
 				)
@@ -1261,19 +1290,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							<button
 								type="button"
 								onClick={() => {
-									toggleAlbumPicker();
-									if (isDrawerOpen) toggleDrawer();
-									if (pendingLocationShare) handleLocationShareRequest();
-								}}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-								aria-label={t("chat.share_album_label")}
-								title={t("chat.share_album_label")}
-							>
-								<Share2 className="h-5 w-5" />
-							</button>
-							<button
-								type="button"
-								onClick={() => {
 									if (!selectedConversation) { toast.error(t("chat.errors.no_conversation_yet", { defaultValue: "Send a text message first to unlock media." })); return; }
 									attachmentInputRef.current?.click();
 									if (isDrawerOpen) toggleDrawer();
@@ -1330,45 +1346,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							/>
 						</div>
 
-						{isAlbumPickerOpen ? (
-							<div className="mb-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-2">
-								{isLoadingAlbums ? (
-									<div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-										<Loader2 className="h-3.5 w-3.5 animate-spin" /> {t("chat.loading_albums")}
-									</div>
-								) : shareableAlbums.length === 0 ? (
-									<p className="text-xs text-[var(--text-muted)]">
-										{t("chat.no_albums_available")}
-									</p>
-								) : (
-									<div className="grid gap-2 sm:grid-cols-2">
-										{shareableAlbums.map((album) => (
-											<div
-												key={album.albumId}
-												className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-2"
-											>
-												<p className="truncate text-xs font-medium">
-													{album.albumName || t("chat.album_fallback", { id: album.albumId })}
-												</p>
-												<button
-													type="button"
-													onClick={() =>
-														void shareAlbumToCurrentConversation(
-															album.albumId,
-															album.albumName,
-														)
-													}
-													disabled={!album.isShareable || isSharingAlbum}
-													className="mt-2 rounded-md border border-[var(--border)] px-2 py-1 text-[11px] text-[var(--text-muted)] disabled:opacity-50"
-												>
-													{t("chat.share")}
-												</button>
-											</div>
-										))}
-									</div>
-								)}
-							</div>
-						) : null}
 
 					</form>
 
@@ -1471,6 +1448,13 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							onSendMedia={onSendDrawerMedia}
 							onAddMedia={onAddDrawerMedia}
 							onDeleteMedia={onDeleteDrawerMedia}
+							onShareAlbum={onShareAlbumFromDrawer}
+							onStopAlbumShare={onStopAlbumShareFromDrawer}
+							albums={shareableAlbums}
+							isLoadingAlbums={isLoadingAlbums}
+							albumCoverMap={albumCoverMap}
+							sharedAlbumIds={sharedAlbumIds}
+							isSharingAlbum={isSharingAlbum}
 							isDesktop={isDesktop}
 						/>
 					) : null}
@@ -1707,6 +1691,21 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 											{t("chat.actions.unsend")}
 										</button>
 									) : null}
+									{(() => {
+										const albumId = getMessageAlbumId(selectedActionMessage);
+										const isViewable = (selectedActionMessage.body as any)?.isViewable;
+										if (!selectedActionMessageMine || !albumId || !isViewable) return null;
+										return (
+											<button
+												type="button"
+												onClick={() => void handleStopAlbumShare(albumId)}
+												disabled={isMutatingMessageId === selectedActionMessage.messageId}
+												className="w-full rounded-xl border border-orange-500/35 bg-orange-500/10 px-3 py-3 text-left text-sm font-medium text-orange-300 transition hover:bg-orange-500/15 disabled:opacity-60"
+											>
+												{t("chat.actions.stop_sharing", { defaultValue: "Stop Sharing" })}
+											</button>
+										);
+									})()}
 									<button
 										type="button"
 										onClick={() => void handleDelete(selectedActionMessage)}
@@ -1729,83 +1728,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						</div>
 					) : null}
 
-					{pendingAlbumShare && albumViewer === null ? (
-						<BottomSheet
-							onClose={isSharingAlbum ? () => {} : closePendingAlbumShare}
-							isProcessing={isSharingAlbum}
-							isDesktop={isDesktop}
-						>
-								<div className="flex items-center justify-between px-4 pb-3">
-									<p
-										id="chat-album-share-confirm-title"
-										className="text-sm font-semibold text-[var(--text)]"
-									>
-										{t("chat.share_album_label")}
-									</p>
-									<SheetClose
-										disabled={isSharingAlbum}
-										className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
-									>
-										<X className="h-4 w-4" />
-									</SheetClose>
-								</div>
-								<div className="px-4 pb-3">
-								<p className="text-sm leading-relaxed text-[var(--text-muted)]">
-									{t("chat.confirm_share_album", {
-										album: pendingAlbumShare.albumName,
-									})}
-								</p>
 
-								<div className="mt-4">
-									<label className="mb-1.5 block text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-										{t("chat.expiration.title")}
-									</label>
-									<div className="relative">
-										<select
-											value={selectedExpirationType}
-											onChange={(e) => setSelectedExpirationType(e.target.value)}
-											className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--surface-2)] py-2.5 pl-10 pr-4 text-sm font-medium text-[var(--text)] transition focus:border-[var(--accent)] focus:outline-none"
-										>
-											<option value="INDEFINITE">{t("chat.expiration.indefinite")}</option>
-											<option value="ONCE">{t("chat.expiration.once")}</option>
-											<option value="TEN_MINUTES">{t("chat.expiration.ten_minutes")}</option>
-											<option value="ONE_HOUR">{t("chat.expiration.one_hour")}</option>
-											<option value="ONE_DAY">{t("chat.expiration.one_day")}</option>
-										</select>
-										<div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
-											{selectedExpirationType === "INDEFINITE" && <Infinity className="h-4 w-4" />}
-											{selectedExpirationType === "ONCE" && <TimerOff className="h-4 w-4" />}
-											{(selectedExpirationType === "TEN_MINUTES" || selectedExpirationType === "ONE_HOUR" || selectedExpirationType === "ONE_DAY") && <Hourglass className="h-4 w-4" />}
-										</div>
-										<div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
-											<ChevronDown className="h-4 w-4" />
-										</div>
-									</div>
-								</div>
-
-								</div>
-								<div className="flex gap-2 p-3">
-									<SheetClose
-										disabled={isSharingAlbum}
-										className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-									>
-										{t("chat.actions.cancel")}
-									</SheetClose>
-									<button
-										type="button"
-										onClick={() => void confirmPendingAlbumShare(selectedExpirationType)}
-										disabled={isSharingAlbum}
-										className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-									>
-										{isSharingAlbum ? (
-											<Loader2 className="mx-auto h-4 w-4 animate-spin" />
-										) : (
-											<span>{t("chat.share")}</span>
-										)}
-									</button>
-								</div>
-						</BottomSheet>
-					) : null}
 		</div>
 	) : (
 		<div

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -575,7 +575,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		};
 	}, [isDesktop]);
 
-	const renderThread = selectedConversation ? (
+	const renderThread = (selectedConversation || targetProfileId) ? (
 		<div
 			className={`flex h-full flex-col ${!isDesktop ? "overflow-hidden p-0" : "overflow-hidden p-3 sm:p-4"} ${
 				isDesktop ? "surface-card" : ""
@@ -589,7 +589,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					: undefined
 			}
 		>
-			{(() => {
+			{selectedConversation ? (() => {
 				const otherParticipant = getOtherParticipant(
 					selectedConversation,
 					userId,
@@ -1055,10 +1055,41 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						/>
 					</>
 				);
-			})()}
+			})() : (
+			<div
+				className={`mb-3 flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3 ${!isDesktop ? "fixed inset-x-0 top-0 z-20 bg-[var(--surface)] py-3 px-[var(--app-px)]" : "-mx-3 sm:-mx-4 px-3 sm:px-4"}`}
+				style={!isDesktop ? { top: 0, paddingTop: "calc(env(safe-area-inset-top, 0px) + clamp(14px, 2.2vw, 28px))" } : undefined}
+			>
+				<div className="min-w-0 flex items-center gap-3">
+					{!isDesktop && (
+						<button
+							type="button"
+							onClick={() => navigate("/")}
+							className="shrink-0 inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
+							aria-label={t("browse_location.back_aria")}
+						>
+							<ChevronLeft className="h-4 w-4" />
+						</button>
+					)}
+					<div className="h-10 w-10 shrink-0 overflow-hidden rounded-full border-2 border-[var(--border)] bg-[var(--surface-2)] flex items-center justify-center">
+						<User className="h-5 w-5 text-[var(--text-muted)]" />
+					</div>
+					<div className="min-w-0">
+						<p className="truncate text-lg font-semibold text-[var(--text-muted)]">{t("chat.new_conversation.title")}</p>
+						<p className="text-sm text-[var(--text-muted)]">{t("chat.new_conversation.subtitle", { profileId: targetProfileId })}</p>
+					</div>
+				</div>
+				<div className="flex items-center gap-2">
+					<button type="button" disabled className="rounded-xl border border-[var(--border)] p-2 text-[var(--text-muted)] opacity-40 cursor-not-allowed" aria-label="Open conversation actions">
+						<Ellipsis className="h-4 w-4" />
+					</button>
+				</div>
+			</div>
+			)}
 
-			{isLoadingThread &&
-			threadConversationId !== selectedConversation.data.conversationId ? (
+			{selectedConversation ? (
+				isLoadingThread &&
+				threadConversationId !== selectedConversation.data.conversationId ? (
 				<div className="flex flex-1 items-center justify-center text-[var(--text-muted)]">
 					<Loader2 className="mr-2 h-4 w-4 animate-spin" /> {t("chat.loading_messages")}
 				</div>
@@ -1079,8 +1110,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					</button>
 				</div>
 			) : (
-				<>
-					<ChatThreadMessages
+				<ChatThreadMessages
 						isDesktop={isDesktop}
 						selectedConversation={selectedConversation}
 						userId={userId}
@@ -1111,7 +1141,19 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						handleRetry={handleRetry}
 						handleReply={handleReply}
 						threadBottomRef={threadBottomRef}
-					/>
+				/>
+				)
+			) : (
+				<div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+					<div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[var(--surface-2)] text-[var(--text-muted)]">
+						<MessageCircleOff className="h-6 w-6 opacity-50" />
+					</div>
+					<div>
+						<p className="text-sm font-medium text-[var(--text-muted)]">{t("chat.new_conversation.no_messages_yet", { defaultValue: "No messages yet" })}</p>
+						<p className="mt-1 text-xs text-[var(--text-muted)] opacity-70">{t("chat.new_conversation.send_first_message_hint", { defaultValue: "Send a message below to start the conversation." })}</p>
+					</div>
+				</div>
+			)}
 
 					<form
 						onSubmit={onFormSubmit}
@@ -1160,7 +1202,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						)}
 						{/* -------------------------- */}
 
-                        {replyTargetMessage ? (
+                        {selectedConversation && replyTargetMessage ? (
 							<div className="mb-2 overflow-hidden rounded-2xl border border-[color-mix(in_srgb,var(--accent)_24%,var(--border))] bg-[color-mix(in_srgb,var(--surface-2)_82%,var(--accent)_8%)] shadow-[0_2px_10px_rgba(0,0,0,0.08)]">
 								<div className="flex items-stretch">
 									<div className="w-1 shrink-0 bg-[var(--accent)]" aria-hidden="true" />
@@ -1172,7 +1214,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 													{`${t("chat.actions.reply", { defaultValue: "Reply" })} · ${
 														userId != null && Number(replyTargetMessage.senderId) === Number(userId)
 															? t("chat.you")
-															: (selectedConversation.data.name?.trim() || t("chat.unknown"))
+															: (selectedConversation?.data.name?.trim() || t("chat.unknown"))
 													}`}
 												</span>
 											</p>
@@ -1202,7 +1244,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								onChange={(event) => setDraft(event.target.value)}
 								rows={1}
 								maxLength={1000}
-								placeholder={t("chat.write_message")}
+								placeholder={selectedConversation ? t("chat.write_message") : t("chat.new_conversation.write_first_message")}
 								className="flex-1 bg-transparent py-1 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none resize-none disabled:opacity-60"
                                 style={{ fieldSizing: "content", maxHeight: "115px" }}
 							/>
@@ -1232,6 +1274,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							<button
 								type="button"
 								onClick={() => {
+									if (!selectedConversation) { toast.error(t("chat.errors.no_conversation_yet", { defaultValue: "Send a text message first to unlock media." })); return; }
 									attachmentInputRef.current?.click();
 									if (isDrawerOpen) toggleDrawer();
 									if (pendingLocationShare) handleLocationShareRequest();
@@ -1246,6 +1289,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							<button
 								type="button"
 								onClick={() => {
+									if (!selectedConversation) { toast.error(t("chat.errors.no_conversation_yet", { defaultValue: "Send a text message first to unlock media." })); return; }
 									toggleDrawer();
 									if (pendingLocationShare) handleLocationShareRequest();
 								}}
@@ -1414,7 +1458,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						</BottomDrawer>
 					) : null}
 
-					{isDrawerOpen ? (
+					{selectedConversation && isDrawerOpen ? (
 						<ChatDrawerPanel
 							media={drawerMedia}
 							isLoading={isLoadingDrawer}
@@ -1762,504 +1806,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								</div>
 						</BottomSheet>
 					) : null}
-				</>
-			)}
-		</div>
-	) : targetProfileId ? (
-		<div
-            className={`flex h-full flex-col overflow-hidden ${!isDesktop ? "overflow-hidden p-0" : "p-3 sm:p-4"} ${
-                isDesktop ? "surface-card" : ""
-            }`}
-            style={
-                !isDesktop
-                    ? {
-                        height:
-                            "calc(100dvh - (env(safe-area-inset-top, 0px) + 16px) - (env(safe-area-inset-bottom, 0px) + 92px))",
-                    }
-                    : undefined
-            }
-        >
-            <div
-                className={`mb-3 flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3 ${!isDesktop ? "fixed inset-x-0 top-0 z-20 bg-[var(--surface)] py-3 px-[var(--app-px)]" : "-mx-3 sm:-mx-4 px-3 sm:px-4"}`}
-                style={
-                    !isDesktop
-                        ? {
-                            top: 0,
-                            paddingTop:
-                                "calc(env(safe-area-inset-top, 0px) + clamp(14px, 2.2vw, 28px))",
-                        }
-                        : undefined
-                }
-            >
-                <div className="min-w-0 flex items-center gap-3">
-                    {!isDesktop && (
-                        <button
-                            type="button"
-                            onClick={() => navigate("/")}
-                            className="shrink-0 inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
-                            aria-label={t("browse_location.back_aria")}
-                        >
-                            <ChevronLeft className="h-4 w-4" />
-                        </button>
-                    )}
-                    <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full border-2 border-[var(--border)] bg-[var(--surface-2)] flex items-center justify-center">
-                        <User className="h-5 w-5 text-[var(--text-muted)]" />
-                    </div>
-                    <div className="min-w-0">
-                        <p className="truncate text-lg font-semibold text-[var(--text-muted)]">
-                            {t("chat.new_conversation.title")}
-                        </p>
-                        <p className="text-sm text-[var(--text-muted)]">
-                            {t("chat.new_conversation.subtitle", { profileId: targetProfileId })}
-                        </p>
-                    </div>
-                </div>
-                <div className="flex items-center gap-2">
-                    <button
-                        type="button"
-                        disabled
-                        className="rounded-xl border border-[var(--border)] p-2 text-[var(--text-muted)] opacity-40 cursor-not-allowed"
-                        aria-label="Open conversation actions"
-                    >
-                        <Ellipsis className="h-4 w-4" />
-                    </button>
-                </div>
-            </div>
-
-            <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
-                <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-dashed border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-muted)]">
-                    <MessageCircleOff className="h-6 w-6 opacity-50" />
-                </div>
-                <div>
-                    <p className="text-sm font-medium text-[var(--text-muted)]">
-                        {t("chat.new_conversation.no_messages_yet", { defaultValue: "No messages yet" })}
-                    </p>
-                    <p className="mt-1 text-xs text-[var(--text-muted)] opacity-70">
-                        {t("chat.new_conversation.send_first_message_hint", { defaultValue: "Send a message below to start the conversation." })}
-                    </p>
-                </div>
-            </div>
-
-			<form
-				onSubmit={onFormSubmit}
-				className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "mt-3 pt-3 -mx-3 sm:-mx-4 px-3 sm:px-4"} border-t border-[var(--border)] bg-[var(--surface)]`}
-                style={
-                    !isDesktop
-                        ? {
-                            bottom: `${mobileKeyboardInset}px`,
-                            paddingBottom: "max(12px, env(safe-area-inset-bottom))",
-                        }
-                        : undefined
-                }
-            >
-				{(isUploadingAttachment || uploadProgress > 0) && (
-					<div
-						className="h-0.5 bg-[var(--surface-2)] mb-3"
-						style={{ marginTop: "-12px", marginLeft: "calc(-1 * var(--app-px))", marginRight: "calc(-1 * var(--app-px))" }}
-					>
-						<div
-							className="h-0.5 bg-[var(--accent)] transition-all duration-300"
-							style={{ width: `${Math.min(100, uploadProgress)}%` }}
-						/>
-					</div>
-				)}
-				{/* --- QUICK PHRASE PILLS --- */}
-				{filteredPhrases.length > 0 && (
-					<div className="mb-2 flex items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-						{filteredPhrases.map((phrase, idx) => {
-							const isExact = phrase.toLowerCase() === draft.trim().toLowerCase();
-							return (
-								<button
-									key={idx}
-									type="button"
-									onClick={() => handleUsePhrase(phrase)}
-									className={`shrink-0 whitespace-nowrap rounded-2xl rounded-br-[3px] border px-3 py-1.5 text-xs font-medium transition active:scale-95 ${
-										isExact
-											? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
-											: "border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
-									}`}
-								>
-									{phrase}
-								</button>
-							);
-						})}
-					</div>
-				)}
-				{/* -------------------------- */}
-
-                <div className="flex items-end gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-1.5 mb-2 focus-within:border-[var(--accent)] transition-colors">
-					<textarea
-						value={draft}
-						onChange={(event) => setDraft(event.target.value)}
-						rows={1}
-						maxLength={1000}
-						placeholder={t("chat.new_conversation.write_first_message")}
-						className="flex-1 bg-transparent py-1 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none resize-none disabled:opacity-60"
-                        style={{ fieldSizing: "content", maxHeight: "115px" }}
-					/>
-					<button
-						type="submit"
-						disabled={isSending || !!pendingLocationShare || draft.trim().length === 0}
-						className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--accent)] transition hover:opacity-80 disabled:opacity-30"
-					>
-						{isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SendHorizontal className="h-4 w-4" />}
-					</button>
-				</div>
-
-				<div className="mb-2 mx-5 flex items-center justify-between gap-2">
-                    <button
-                        type="button"
-                        onClick={() => {
-							toggleAlbumPicker();
-							if (isDrawerOpen) toggleDrawer();
-							if (pendingLocationShare) handleLocationShareRequest();
-						}}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-                        aria-label={t("chat.share_album_label")}
-                        title={t("chat.share_album_label")}
-                    >
-                        <Share2 className="h-5 w-5" />
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => {
-							attachmentInputRef.current?.click();
-							if (isDrawerOpen) toggleDrawer();
-							if (pendingLocationShare) handleLocationShareRequest();
-						}}
-                        disabled={isUploadingAttachment}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-                        aria-label={t("chat.attach_media")}
-                        title={t("chat.attach_media")}
-                    >
-                        <ImagePlus className="h-5 w-5" />
-                    </button>
-                    <button
-                        type="button"
-                        disabled
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] opacity-40 cursor-not-allowed"
-                        aria-label={t("chat.drawer_label")}
-                        title={t("chat.drawer_unavailable", { defaultValue: "Send a message first to use the drawer" })}
-                    >
-                        <SquareStack className="h-5 w-5" />
-                    </button>
-					<button
-                        type="button"
-                        onClick={() => {
-							handleLocationShareRequest();
-							if (isDrawerOpen) toggleDrawer();
-						}}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-                        aria-label={t("chat.share_location_label", { defaultValue: "Share Location" })}
-                        title={t("chat.share_location_label", { defaultValue: "Share Location" })}
-                    >
-                        <MapPin className="h-5 w-5" />
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => setIsSavedPhrasesOpen((prev) => !prev)}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:text-[var(--text)]"
-                        aria-label={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
-                        title={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
-                    >
-                        <BookMarked className="h-5 w-5" />
-                    </button>
-
-                    <input
-                        type="file"
-                        ref={attachmentInputRef}
-                        onChange={onAttachmentInput}
-                        accept="image/*,video/*"
-                        className="hidden"
-                    />
-                </div>
-
-                {isAlbumPickerOpen ? (
-                    <div className="mb-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-2">
-                        {isLoadingAlbums ? (
-                            <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-                                <Loader2 className="h-3.5 w-3.5 animate-spin" /> {t("chat.loading_albums")}
-                            </div>
-                        ) : shareableAlbums.length === 0 ? (
-                            <p className="text-xs text-[var(--text-muted)]">
-                                {t("chat.no_albums_available")}
-                            </p>
-                        ) : (
-                            <div className="grid gap-2 sm:grid-cols-2">
-                                {shareableAlbums.map((album) => (
-                                    <div
-                                        key={album.albumId}
-                                        className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-2"
-                                    >
-                                        <p className="truncate text-xs font-medium">
-                                            {album.albumName || t("chat.album_fallback", { id: album.albumId })}
-                                        </p>
-                                        <button
-                                            type="button"
-                                            onClick={() =>
-                                                void shareAlbumToCurrentConversation(
-                                                    album.albumId,
-                                                    album.albumName,
-                                                )
-                                            }
-                                            disabled={!album.isShareable || isSharingAlbum}
-                                            className="mt-2 rounded-md border border-[var(--border)] px-2 py-1 text-[11px] text-[var(--text-muted)] disabled:opacity-50"
-                                        >
-                                            {t("chat.share")}
-                                        </button>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                    </div>
-                ) : null}
-
-			</form>
-
-			{pendingAttachmentFile ? (
-				<BottomDrawer
-					title={t("chat.attachments.ready_to_send", { file: pendingAttachmentFile.name })}
-					onClose={cancelPendingAttachment}
-					onConfirm={() => void handleConfirmAttachment()}
-					confirmLabel={t("chat.attachments.send_attachment")}
-					cancelLabel={t("chat.actions.cancel")}
-					isProcessing={isUploadingAttachment}
-					isDesktop={isDesktop}
-				>
-					{attachmentPreviewUrl && (
-						pendingAttachmentFile.type.startsWith("video/") ? (
-							<div className="px-3 pb-3">
-								<video src={attachmentPreviewUrl} controls className="w-full object-contain rounded-xl border border-[var(--border)]" style={{ maxHeight: "40dvh" }} />
-							</div>
-						) : (
-							<div className="px-3 pb-3">
-								<div className="flex justify-center">
-									<style>{`
-										@keyframes attach-logo-shine { 0%, 100% { filter: drop-shadow(0 0 2px rgba(255,140,0,0.3)) brightness(1); } 50% { filter: drop-shadow(0 0 7px rgba(255,140,0,0.95)) brightness(1.25); } }
-										.attach-logo-shine { animation: attach-logo-shine 2.8s ease-in-out infinite; }
-										.attach-crop .ReactCrop__crop-mask { display: none !important; } .attach-crop .ReactCrop__crop-selection { background-image: none !important; animation: none !important; outline: none !important; border: 3px solid rgba(255,255,255,0.6) !important; border-radius: 11px !important; box-shadow: 0 0 0 9999px rgba(0,0,0,0.5) !important; }
-										.attach-crop .ord-n, .attach-crop .ord-s, .attach-crop .ord-e, .attach-crop .ord-w { display: none !important; }
-										.attach-crop .ReactCrop__drag-handle { background: transparent !important; border: none !important; width: 15px !important; height: 15px !important; }
-										.attach-crop .ord-nw { transform: translate(4px, 4px) !important; border-top: 2px solid white !important; border-left: 2px solid white !important; }
-										.attach-crop .ord-ne { transform: translate(-4px, 4px) !important; border-top: 2px solid white !important; border-right: 2px solid white !important; }
-										.attach-crop .ord-sw { transform: translate(4px, -4px) !important; border-bottom: 2px solid white !important; border-left: 2px solid white !important; }
-										.attach-crop .ord-se { transform: translate(-4px, -4px) !important; border-bottom: 2px solid white !important; border-right: 2px solid white !important; }
-									`}</style>
-									<div className="relative rounded-xl border border-[var(--border)] overflow-hidden">
-									<ReactCrop
-										crop={attachmentCrop}
-										onChange={(c) => { setIsDraggingAttachmentCrop(true); setAttachmentCrop(c); }}
-										onComplete={(c) => { setIsDraggingAttachmentCrop(false); setAttachmentCompletedCrop(c); }}
-										ruleOfThirds={isDraggingAttachmentCrop}
-										minWidth={150}
-										minHeight={150}
-										className="attach-crop ReactCrop--no-animate"
-										style={{ maxHeight: "45dvh", display: "block" }}
-									>
-										<img ref={attachmentImgRef} src={attachmentPreviewUrl} alt="Preview" className="block" style={{ maxHeight: "45dvh" }} />
-									</ReactCrop>
-									{attachmentTakenOnGrindr && attachmentCrop && (
-										<div
-											className="absolute inline-flex items-center gap-1.5 pointer-events-none"
-											style={{
-												left: `calc(${attachmentCrop.unit === "%" ? attachmentCrop.x + "%" : attachmentCrop.x + "px"} + 10px)`,
-												top: `calc(${attachmentCrop.unit === "%" ? (attachmentCrop.y + attachmentCrop.height) + "%" : (attachmentCrop.y + attachmentCrop.height) + "px"} - 10px)`,
-												transform: "translateY(-100%)",
-											}}
-										>
-											<img src={freegrindLogo} alt="" className="h-5 w-5 rounded-full attach-logo-shine" />
-											<span className="inline-flex items-center gap-1 rounded-full bg-black/65 px-2 py-1 text-[10px] font-semibold text-white">
-												<span>{t("chat.time.just_now", { defaultValue: "just now" })}</span>
-											</span>
-										</div>
-									)}
-									</div>
-								</div>
-								<div className="mt-3 flex items-center justify-center gap-8">
-									<button type="button" onClick={() => void applyAttachmentTransform("flipH")} className="text-[var(--text-muted)] transition hover:text-[var(--text)]" aria-label="Flip horizontal">
-										<SquareCenterlineDashedHorizontal className="h-6 w-6" />
-									</button>
-									<button type="button" onClick={() => void applyAttachmentTransform("rotateCw")} className="text-[var(--text-muted)] transition hover:text-[var(--text)]" aria-label="Rotate clockwise">
-										<RotateCw className="h-6 w-6" />
-									</button>
-								</div>
-							</div>
-						)
-					)}
-					<div className="px-3 pb-3 grid gap-3">
-						<ToggleRow 
-                            checked={attachmentLooping}
-                            onChange={setAttachmentLooping}
-                            label={t("chat.attachments.looping")}
-                        />
-                        <ToggleRow
-                            checked={attachmentTakenOnGrindr}
-                            onChange={setAttachmentTakenOnGrindr}
-                            label={t("chat.attachments.taken_on_grindr")}
-                            description={t("chat.attachments.taken_on_grindr_description")}
-                        />
-					</div>
-				</BottomDrawer>
-			) : null}
-
-			{pendingLocationShare ? (
-				<BottomDrawer
-					title={t("chat.share_location_confirm", { defaultValue: "Share this location?" })}
-					onClose={() => setPendingLocationShare(null)}
-					onConfirm={() => {
-						void onSendLocation(pendingLocationShare.lat, pendingLocationShare.lon);
-						setPendingLocationShare(null);
-					}}
-					confirmLabel={t("chat.send")}
-					isDesktop={isDesktop}
-				>
-					<div className="px-3 pb-3">
-						<div className="overflow-hidden rounded-xl border border-[var(--border)]" style={{ height: "40dvh" }}>
-							<LeafletLocationPicker
-								selectedLocation={pendingLocationShare}
-								onPick={(lat, lon) => setPendingLocationShare({ lat, lon })}
-								onError={(msg) => toast.error(msg)}
-								className="h-full w-full"
-								defaultZoom={18}
-							/>
-						</div>
-					</div>
-				</BottomDrawer>
-			) : null}
-
-            {pendingAlbumShare && albumViewer === null ? (
-                <BottomSheet
-                    onClose={isSharingAlbum ? () => {} : closePendingAlbumShare}
-                    isProcessing={isSharingAlbum}
-                    isDesktop={true}
-                >
-                        <div className="flex items-center justify-between px-4 py-3">
-                            <p
-                                id="chat-album-share-confirm-title"
-                                className="text-sm font-semibold text-[var(--text)]"
-                            >
-                                {t("chat.share_album_label")}
-                            </p>
-                            <SheetClose
-                                disabled={isSharingAlbum}
-                                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
-                            >
-                                <X className="h-4 w-4" />
-                            </SheetClose>
-                        </div>
-                        <div className="px-4 pb-3">
-                        <p className="text-sm leading-relaxed text-[var(--text-muted)]">
-                            {t("chat.confirm_share_album", {
-                                album: pendingAlbumShare.albumName,
-                            })}
-                        </p>
-
-                        <div className="mt-4">
-                            <label className="mb-1.5 block text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-                                {t("chat.expiration.title")}
-                            </label>
-                            <div className="relative">
-                                <select
-                                    value={selectedExpirationType}
-                                    onChange={(e) => setSelectedExpirationType(e.target.value)}
-                                    className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--surface-2)] py-2.5 pl-10 pr-4 text-sm font-medium text-[var(--text)] transition focus:border-[var(--accent)] focus:outline-none"
-                                >
-                                    <option value="INDEFINITE">{t("chat.expiration.indefinite")}</option>
-                                    <option value="ONCE">{t("chat.expiration.once")}</option>
-                                    <option value="TEN_MINUTES">{t("chat.expiration.ten_minutes")}</option>
-                                    <option value="ONE_HOUR">{t("chat.expiration.one_hour")}</option>
-                                    <option value="ONE_DAY">{t("chat.expiration.one_day")}</option>
-                                </select>
-                                <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
-                                    {selectedExpirationType === "INDEFINITE" && <Infinity className="h-4 w-4" />}
-                                    {selectedExpirationType === "ONCE" && <TimerOff className="h-4 w-4" />}
-                                    {(selectedExpirationType === "TEN_MINUTES" || selectedExpirationType === "ONE_HOUR" || selectedExpirationType === "ONE_DAY") && <Hourglass className="h-4 w-4" />}
-                                </div>
-                                <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
-                                    <ChevronDown className="h-4 w-4" />
-                                </div>
-                            </div>
-                        </div>
-
-                        </div>
-                        <div className="flex gap-2 p-3" style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}>
-                            <SheetClose
-                                disabled={isSharingAlbum}
-                                className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-                            >
-                                {t("chat.actions.cancel")}
-                            </SheetClose>
-                            <button
-                                type="button"
-                                onClick={() => void confirmPendingAlbumShare(selectedExpirationType)}
-                                disabled={isSharingAlbum}
-                                className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
-                            >
-                                {isSharingAlbum ? (
-                                    <Loader2 className="mx-auto h-4 w-4 animate-spin" />
-                                ) : (
-                                    <span>{t("chat.share")}</span>
-                                )}
-                            </button>
-                        </div>
-                </BottomSheet>
-            ) : null}
-
-			{isSavedPhrasesOpen ? (
-				<BottomSheet
-					onClose={() => { setPhrasesExpanded(false); setIsSavedPhrasesOpen(false); }}
-					onExpand={() => setPhrasesExpanded(true)}
-					isDesktop={isDesktop}
-					bg="bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)]"
-				>
-					<div className="flex items-center justify-between px-4 pb-3">
-						<div className="flex items-center gap-2">
-							<p className="text-sm font-semibold text-[var(--text)]">{t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}</p>
-							{savedPhrases.length > 0 && (
-								<span className="rounded-full bg-[var(--surface-2)] px-2 py-0.5 text-[11px] font-semibold tabular-nums text-[var(--text-muted)]">{savedPhrases.length}</span>
-							)}
-						</div>
-						<div className="flex items-center gap-1">
-							<button type="button" onClick={() => { setIsSavedPhrasesOpen(false); navigate("/settings/saved-phrases"); }} className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]" aria-label={t("chat.saved_phrases_manage", { defaultValue: "Manage" })}>
-								<Settings2 className="h-4 w-4" />
-							</button>
-							<SheetClose className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]">
-								<X className="h-4 w-4" />
-							</SheetClose>
-						</div>
-					</div>
-					<div className="px-3 pb-3">
-						<div className="flex gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-1.5">
-							<input type="text" value={newPhraseInput} onChange={(e) => setNewPhraseInput(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAddPhrase(); } }} placeholder={t("settings_saved_phrases.new_placeholder", { defaultValue: "Add a new phrase..." })} className="min-w-0 flex-1 bg-transparent px-2 text-sm text-[var(--text)] placeholder-[var(--text-muted)] outline-none" />
-							<button type="button" onClick={handleAddPhrase} disabled={!newPhraseInput.trim()} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-[var(--accent)] px-3 text-xs font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-40">
-								<Plus className="h-3.5 w-3.5" />
-								{t("settings_saved_phrases.add", { defaultValue: "Add" })}
-							</button>
-						</div>
-					</div>
-					<div className="border-t border-[var(--border)]" />
-					<div data-lenis-prevent className="overflow-y-auto" style={{ maxHeight: phrasesExpanded ? "72dvh" : "40dvh", transition: "max-height 0.25s ease" }}>
-						{savedPhrases.length === 0 ? (
-							<div className="flex flex-col items-center gap-2.5 py-8 text-[var(--text-muted)]">
-								<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--surface-2)]"><BookMarked className="h-5 w-5 opacity-60" /></div>
-								<p className="text-sm font-medium">{t("settings_saved_phrases.empty", { defaultValue: "No saved phrases yet." })}</p>
-								<p className="text-xs opacity-60">{t("settings_saved_phrases.empty_hint", { defaultValue: "Type above to add your first phrase." })}</p>
-							</div>
-						) : (
-							<div>
-								{savedPhrases.map((phrase, originalIndex) => (
-									<div key={originalIndex} className="group flex items-center px-4">
-										<div className="flex flex-1 items-center gap-1 py-3">
-											<SheetClose onClick={() => handleUsePhrase(phrase)} className="min-w-0 flex-1 text-left text-sm text-[var(--text)] transition hover:text-[var(--accent)]">{phrase}</SheetClose>
-											<button type="button" onClick={() => handleDeletePhrase(originalIndex)} className="shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-red-400" aria-label={t("settings_saved_phrases.delete", { defaultValue: "Delete phrase" })}><Trash2 className="h-3.5 w-3.5" /></button>
-										</div>
-									</div>
-								))}
-							</div>
-						)}
-					</div>
-				</BottomSheet>
-			) : null}
 		</div>
 	) : (
 		<div

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1169,7 +1169,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						handleRetry={handleRetry}
 						handleReply={handleReply}
 						handleStopAlbumShare={handleStopAlbumShare}
-						albumCoverMap={albumCoverMap}
 						threadBottomRef={threadBottomRef}
 				/>
 				)
@@ -1306,7 +1305,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							<button
 								type="button"
 								onClick={() => {
-									if (!selectedConversation) { toast.error(t("chat.errors.no_conversation_yet", { defaultValue: "Send a text message first to unlock media." })); return; }
 									toggleDrawer();
 									if (pendingLocationShare) handleLocationShareRequest();
 								}}
@@ -1436,7 +1434,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						</BottomDrawer>
 					) : null}
 
-					{selectedConversation && isDrawerOpen ? (
+					{isDrawerOpen ? (
 						<ChatDrawerPanel
 							media={drawerMedia}
 							isLoading={isLoadingDrawer}
@@ -1457,6 +1455,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							sharedAlbumIds={sharedAlbumIds}
 							isSharingAlbum={isSharingAlbum}
 							isDesktop={isDesktop}
+							noConversation={!selectedConversation}
 						/>
 					) : null}
 

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1438,7 +1438,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								setPendingLocationShare(null);
 							}}
 							confirmLabel={t("chat.send")}
-							cancelLabel={t("chat.actions.cancel")}
 							isDesktop={isDesktop}
 						>
 							<div className="px-3 pb-3">

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -11,6 +11,7 @@ import {
 	Infinity,
 	Loader2,
 	MapPin,
+	BookMarked,
 	MessageCircleOff,
 	MessageCircleX,
 	PencilLine,
@@ -1242,6 +1243,15 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 									<MapPin className="h-5 w-5" />
 								)}
 							</button>
+							<button
+								type="button"
+								onClick={() => navigate("/settings/saved-phrases")}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+								aria-label={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
+								title={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
+							>
+								<BookMarked className="h-5 w-5" />
+							</button>
 
 							<input
 								type="file"
@@ -1824,6 +1834,15 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                         ) : (
                             <MapPin className="h-5 w-5" />
                         )}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => navigate("/settings/saved-phrases")}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+                        aria-label={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
+                        title={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
+                    >
+                        <BookMarked className="h-5 w-5" />
                     </button>
 
                     <input

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -38,7 +38,6 @@ import type { NavigateFunction } from "react-router-dom";
 import toast from "react-hot-toast";
 import { appLog } from "../../../utils/logger";
 import {
-	createBackdropCloseHandler,
 	useModalClose,
 } from "../../../hooks/useModalClose";
 import type { AlbumListItem, AlbumViewerState, UiMessage } from "../../../types/chat-page";
@@ -67,6 +66,7 @@ import { useApiFunctions } from "../../../hooks/useApiFunctions";
 import { isChatGhosted, toggleChatGhost } from "../../../utils/privacy";
 import { ToggleRow } from "../../../components/ui/toggle-row";
 import { BottomDrawer } from "../../../components/ui/bottom-drawer";
+import { BottomSheet } from "../../../components/ui/bottom-sheet";
 import {
 	loadSavedPhrases,
 	saveSavedPhrases,
@@ -188,6 +188,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 	const [selectedExpirationType, setSelectedExpirationType] = useState("INDEFINITE");
 	const [pendingLocationShare, setPendingLocationShare] = useState<{ lat: number; lon: number } | null>(null);
 	const [isSavedPhrasesOpen, setIsSavedPhrasesOpen] = useState(false);
+	const [phrasesExpanded, setPhrasesExpanded] = useState(false);
 	const [newPhraseInput, setNewPhraseInput] = useState("");
 
 	const [attachmentPreviewUrl, setAttachmentPreviewUrl] = useState<string | null>(null);
@@ -571,9 +572,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		};
 	}, [isDesktop]);
 
-	const handlePendingAlbumShareBackdropClose = createBackdropCloseHandler(
-		closePendingAlbumShare,
-	);
 	const renderThread = selectedConversation ? (
 		<div
 			className={`flex h-full flex-col ${!isDesktop ? "overflow-hidden p-0" : "overflow-hidden p-3 sm:p-4"} ${
@@ -1457,19 +1455,17 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                     ) : null}
 
 					{isSavedPhrasesOpen ? (
-						<div
-							className="fixed inset-0 z-[60] flex items-end bg-black/45 backdrop-blur-sm no-touch-callout"
-							onClick={() => setIsSavedPhrasesOpen(false)}
+						<BottomSheet
+							onClose={() => {
+								if (phrasesExpanded) setPhrasesExpanded(false);
+								else setIsSavedPhrasesOpen(false);
+							}}
+							onExpand={() => setPhrasesExpanded(true)}
+							isDesktop={isDesktop}
+							bg="bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)]"
 						>
-							<div
-								role="dialog"
-								aria-modal="true"
-								className={`flex w-full flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"}`}
-								style={{ paddingBottom: "max(16px, env(safe-area-inset-bottom))" }}
-								onClick={(e) => e.stopPropagation()}
-							>
-								{/* Header */}
-								<div className="flex items-center justify-between px-4 pt-4 pb-3">
+							{/* Header */}
+							<div className="flex items-center justify-between px-4 pb-3">
 									<div className="flex items-center gap-2">
 										<p className="text-sm font-semibold text-[var(--text)]">
 											{t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
@@ -1526,7 +1522,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								<div className="border-t border-[var(--border)]" />
 
 								{/* Phrases list */}
-								<div data-lenis-prevent className="overflow-y-auto max-h-[40dvh]">
+								<div data-lenis-prevent className="overflow-y-auto" style={{ maxHeight: phrasesExpanded ? "72dvh" : "40dvh", transition: "max-height 0.25s ease" }}>
 									{savedPhrases.length === 0 ? (
 										<div className="flex flex-col items-center gap-2.5 py-8 text-[var(--text-muted)]">
 											<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--surface-2)]">
@@ -1568,8 +1564,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 										</div>
 									)}
 								</div>
-							</div>
-						</div>
+						</BottomSheet>
 					) : null}
 
 					{!isDesktop && selectedActionMessage && albumViewer === null ? (
@@ -1697,18 +1692,12 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					) : null}
 
 					{pendingAlbumShare && albumViewer === null ? (
-						<div
-							className="fixed inset-0 z-[60] flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout"
-							onClick={isSharingAlbum ? undefined : handlePendingAlbumShareBackdropClose}
+						<BottomSheet
+							onClose={isSharingAlbum ? () => {} : closePendingAlbumShare}
+							isProcessing={isSharingAlbum}
+							isDesktop={isDesktop}
 						>
-							<div
-								role="dialog"
-								aria-modal="true"
-								aria-labelledby="chat-album-share-confirm-title"
-								className={`flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"}`}
-								onClick={(event) => event.stopPropagation()}
-							>
-								<div className="flex items-center justify-between px-4 py-3">
+								<div className="flex items-center justify-between px-4 pb-3">
 									<p
 										id="chat-album-share-confirm-title"
 										className="text-sm font-semibold text-[var(--text)]"
@@ -1781,8 +1770,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 										)}
 									</button>
 								</div>
-							</div>
-						</div>
+						</BottomSheet>
 					) : null}
 				</>
 			)}
@@ -2142,17 +2130,11 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 			) : null}
 
             {pendingAlbumShare && albumViewer === null ? (
-                <div
-                    className="fixed inset-0 z-[60] flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout"
-                    onClick={isSharingAlbum ? undefined : handlePendingAlbumShareBackdropClose}
+                <BottomSheet
+                    onClose={isSharingAlbum ? () => {} : closePendingAlbumShare}
+                    isProcessing={isSharingAlbum}
+                    isDesktop={true}
                 >
-                    <div
-                        role="dialog"
-                        aria-modal="true"
-                        aria-labelledby="chat-album-share-confirm-title"
-                        className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden w-full max-w-[800px] mx-auto"
-                        onClick={(event) => event.stopPropagation()}
-                    >
                         <div className="flex items-center justify-between px-4 py-3">
                             <p
                                 id="chat-album-share-confirm-title"
@@ -2226,8 +2208,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                                 )}
                             </button>
                         </div>
-                    </div>
-                </div>
+                </BottomSheet>
             ) : null}
 		</div>
 	) : (

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -66,7 +66,7 @@ import { useApiFunctions } from "../../../hooks/useApiFunctions";
 import { isChatGhosted, toggleChatGhost } from "../../../utils/privacy";
 import { ToggleRow } from "../../../components/ui/toggle-row";
 import { BottomDrawer } from "../../../components/ui/bottom-drawer";
-import { BottomSheet } from "../../../components/ui/bottom-sheet";
+import { BottomSheet, SheetClose } from "../../../components/ui/bottom-sheet";
 import {
 	loadSavedPhrases,
 	saveSavedPhrases,
@@ -515,7 +515,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 	useModalClose({
 		isOpen: pendingAlbumShare !== null,
 		onClose: closePendingAlbumShare,
-		escapeKey: !isSharingAlbum,
+		escapeKey: false,
 	});
 
 	useModalClose({
@@ -533,6 +533,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 	useModalClose({
 		isOpen: isSavedPhrasesOpen,
 		onClose: () => setIsSavedPhrasesOpen(false),
+		escapeKey: false,
 	});
 
 	useEffect(() => {
@@ -1205,7 +1206,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							/>
 							<button
 								type="submit"
-								disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
+								disabled={isSending || !!pendingLocationShare || draft.trim().length === 0}
 								className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--accent)] transition hover:opacity-80 disabled:opacity-30"
 							>
 								{isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SendHorizontal className="h-4 w-4" />}
@@ -1486,13 +1487,9 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 										>
 											<Settings2 className="h-4 w-4" />
 										</button>
-										<button
-											type="button"
-											onClick={() => setIsSavedPhrasesOpen(false)}
-											className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
-										>
+										<SheetClose className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)]">
 											<X className="h-4 w-4" />
-										</button>
+										</SheetClose>
 									</div>
 								</div>
 
@@ -1540,16 +1537,12 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 											{savedPhrases.map((phrase, originalIndex) => (
 												<div key={originalIndex} className="group flex items-center px-4">
 													<div className="flex flex-1 items-center gap-1 py-3">
-														<button
-															type="button"
-															onClick={() => {
-																handleUsePhrase(phrase);
-																setIsSavedPhrasesOpen(false);
-															}}
+														<SheetClose
+															onClick={() => handleUsePhrase(phrase)}
 															className="min-w-0 flex-1 text-left text-sm text-[var(--text)] transition hover:text-[var(--accent)]"
 														>
 															{phrase}
-														</button>
+														</SheetClose>
 														<button
 															type="button"
 															onClick={() => handleDeletePhrase(originalIndex)}
@@ -1704,14 +1697,12 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 									>
 										{t("chat.share_album_label")}
 									</p>
-									<button
-										type="button"
-										onClick={closePendingAlbumShare}
+									<SheetClose
 										disabled={isSharingAlbum}
 										className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
 									>
 										<X className="h-4 w-4" />
-									</button>
+									</SheetClose>
 								</div>
 								<div className="px-4 pb-3">
 								<p className="text-sm leading-relaxed text-[var(--text-muted)]">
@@ -1748,15 +1739,13 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								</div>
 
 								</div>
-								<div className="flex gap-2 p-3" style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}>
-									<button
-										type="button"
-										onClick={closePendingAlbumShare}
+								<div className="flex gap-2 p-3">
+									<SheetClose
 										disabled={isSharingAlbum}
 										className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
 									>
 										{t("chat.actions.cancel")}
-									</button>
+									</SheetClose>
 									<button
 										type="button"
 										onClick={() => void confirmPendingAlbumShare(selectedExpirationType)}
@@ -1900,7 +1889,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					/>
 					<button
 						type="submit"
-						disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
+						disabled={isSending || !!pendingLocationShare || draft.trim().length === 0}
 						className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-sm bg-[var(--accent)] text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-40"
 					>
 						{isSending ? <Loader2 className="h-4 w-4 animate-spin" /> : <SendHorizontal className="h-4 w-4" />}
@@ -2142,14 +2131,12 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                             >
                                 {t("chat.share_album_label")}
                             </p>
-                            <button
-                                type="button"
-                                onClick={closePendingAlbumShare}
+                            <SheetClose
                                 disabled={isSharingAlbum}
                                 className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
                             >
                                 <X className="h-4 w-4" />
-                            </button>
+                            </SheetClose>
                         </div>
                         <div className="px-4 pb-3">
                         <p className="text-sm leading-relaxed text-[var(--text-muted)]">
@@ -2187,14 +2174,12 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 
                         </div>
                         <div className="flex gap-2 p-3" style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}>
-                            <button
-                                type="button"
-                                onClick={closePendingAlbumShare}
+                            <SheetClose
                                 disabled={isSharingAlbum}
                                 className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
                             >
                                 {t("chat.actions.cancel")}
-                            </button>
+                            </SheetClose>
                             <button
                                 type="button"
                                 onClick={() => void confirmPendingAlbumShare(selectedExpirationType)}

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -654,7 +654,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 				return (
 					<>
 						<div
-							className={`mb-3 flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3 ${!isDesktop ? "fixed inset-x-0 top-0 z-20 bg-[var(--surface)] py-3 px-[var(--app-px)]" : ""}`}
+							className={`mb-3 flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3 ${!isDesktop ? "fixed inset-x-0 top-0 z-20 bg-[var(--surface)] py-3 px-[var(--app-px)]" : "-mx-3 sm:-mx-4 px-3 sm:px-4"}`}
 							style={
 								!isDesktop
 									? {
@@ -1114,7 +1114,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 
 					<form
 						onSubmit={onFormSubmit}
-						className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "mt-3 pt-3"} border-t border-[var(--border)] bg-[var(--surface)]`}
+						className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "mt-3 pt-3 -mx-3 sm:-mx-4 px-3 sm:px-4"} border-t border-[var(--border)] bg-[var(--surface)]`}
 						style={
 							!isDesktop
 								? {
@@ -1135,24 +1135,29 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								/>
 							</div>
 						)}
-						<div className="flex items-end gap-2 mb-2">
-                            {/* --- QUICK PHRASE PILLS --- */}
-							{filteredPhrases.length > 0 && (
-								<div className="flex flex-1 items-center gap-2 overflow-x-auto pb-1 -mb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-									{filteredPhrases.map((phrase, idx) => (
+						{/* --- QUICK PHRASE PILLS --- */}
+						{filteredPhrases.length > 0 && (
+							<div className="mb-2 flex items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+								{filteredPhrases.map((phrase, idx) => {
+									const isExact = phrase.toLowerCase() === draft.trim().toLowerCase();
+									return (
 										<button
 											key={idx}
 											type="button"
 											onClick={() => handleUsePhrase(phrase)}
-											className="shrink-0 whitespace-nowrap rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)] active:scale-95"
+											className={`shrink-0 whitespace-nowrap rounded-2xl rounded-bl-[3px] border px-3 py-1.5 text-xs font-medium transition active:scale-95 ${
+												isExact
+													? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
+													: "border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
+											}`}
 										>
 											{phrase}
 										</button>
-									))}
-								</div>
-							)}
-							{/* -------------------------- */}
-                        </div>
+									);
+								})}
+							</div>
+						)}
+						{/* -------------------------- */}
 
                         {replyTargetMessage ? (
 							<div className="mb-2 overflow-hidden rounded-2xl border border-[color-mix(in_srgb,var(--accent)_24%,var(--border))] bg-[color-mix(in_srgb,var(--surface-2)_82%,var(--accent)_8%)] shadow-[0_2px_10px_rgba(0,0,0,0.08)]">
@@ -1255,24 +1260,16 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 									handleLocationShareRequest();
 									if (isDrawerOpen) toggleDrawer();
 								}}
-								className={`inline-flex h-9 w-9 items-center justify-center rounded-xl transition ${
-									pendingLocationShare
-										? "bg-[var(--accent)] text-[var(--accent-contrast)]"
-										: "text-[var(--text-muted)] hover:text-[var(--text)]"
-								}`}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:text-[var(--text)]"
 								aria-label={t("chat.share_location_label", { defaultValue: "Share Location" })}
 								title={t("chat.share_location_label", { defaultValue: "Share Location" })}
 							>
-								{pendingLocationShare ? (
-									<X className="h-5 w-5" />
-								) : (
-									<MapPin className="h-5 w-5" />
-								)}
+								<MapPin className="h-5 w-5" />
 							</button>
 							<button
 								type="button"
 								onClick={() => setIsSavedPhrasesOpen((prev) => !prev)}
-								className={`inline-flex h-9 w-9 items-center justify-center rounded-xl transition ${isSavedPhrasesOpen ? "bg-[var(--accent)] text-[var(--accent-contrast)]" : "text-[var(--text-muted)] hover:text-[var(--text)]"}`}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:text-[var(--text)]"
 								aria-label={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
 								title={t("chat.saved_phrases_label", { defaultValue: "Saved Phrases" })}
 							>
@@ -1529,7 +1526,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								<div className="border-t border-[var(--border)]" />
 
 								{/* Phrases list */}
-								<div data-lenis-prevent className="overflow-y-auto max-h-[40dvh] p-3">
+								<div data-lenis-prevent className="overflow-y-auto max-h-[40dvh]">
 									{savedPhrases.length === 0 ? (
 										<div className="flex flex-col items-center gap-2.5 py-8 text-[var(--text-muted)]">
 											<div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--surface-2)]">
@@ -1543,30 +1540,29 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 											</p>
 										</div>
 									) : (
-										<div className="grid gap-1">
+										<div>
 											{savedPhrases.map((phrase, originalIndex) => (
-												<div
-													key={originalIndex}
-													className="flex items-center rounded-xl transition hover:bg-[var(--surface-2)]"
-												>
-													<button
-														type="button"
-														onClick={() => {
-															handleUsePhrase(phrase);
-															setIsSavedPhrasesOpen(false);
-														}}
-														className="min-w-0 flex-1 px-3 py-2.5 text-left text-sm text-[var(--text)]"
-													>
-														{phrase}
-													</button>
-													<button
-														type="button"
-														onClick={() => handleDeletePhrase(originalIndex)}
-														className="mr-1.5 shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-red-400"
-														aria-label={t("settings_saved_phrases.delete", { defaultValue: "Delete phrase" })}
-													>
-														<Trash2 className="h-3.5 w-3.5" />
-													</button>
+												<div key={originalIndex} className="group flex items-center px-4">
+													<div className="flex flex-1 items-center gap-1 py-3">
+														<button
+															type="button"
+															onClick={() => {
+																handleUsePhrase(phrase);
+																setIsSavedPhrasesOpen(false);
+															}}
+															className="min-w-0 flex-1 text-left text-sm text-[var(--text)] transition hover:text-[var(--accent)]"
+														>
+															{phrase}
+														</button>
+														<button
+															type="button"
+															onClick={() => handleDeletePhrase(originalIndex)}
+															className="shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-red-400"
+															aria-label={t("settings_saved_phrases.delete", { defaultValue: "Delete phrase" })}
+														>
+															<Trash2 className="h-3.5 w-3.5" />
+														</button>
+													</div>
 												</div>
 											))}
 										</div>
@@ -1806,7 +1802,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
             }
         >
             <div
-                className={`mb-3 flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3 ${!isDesktop ? "fixed inset-x-0 top-0 z-20 bg-[var(--surface)] py-3 px-[var(--app-px)]" : ""}`}
+                className={`mb-3 flex items-center justify-between gap-3 border-b border-[var(--border)] pb-3 ${!isDesktop ? "fixed inset-x-0 top-0 z-20 bg-[var(--surface)] py-3 px-[var(--app-px)]" : "-mx-3 sm:-mx-4 px-3 sm:px-4"}`}
                 style={
                     !isDesktop
                         ? {
@@ -1868,7 +1864,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 
 			<form
 				onSubmit={onFormSubmit}
-				className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "mt-3 pt-3"} border-t border-[var(--border)] bg-[var(--surface)]`}
+				className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "mt-3 pt-3 -mx-3 sm:-mx-4 px-3 sm:px-4"} border-t border-[var(--border)] bg-[var(--surface)]`}
                 style={
                     !isDesktop
                         ? {
@@ -1966,19 +1962,11 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							handleLocationShareRequest();
 							if (isDrawerOpen) toggleDrawer();
 						}}
-                        className={`inline-flex h-9 w-9 items-center justify-center rounded-xl transition ${
-                            pendingLocationShare
-                                ? "bg-[var(--accent)] text-[var(--accent-contrast)]"
-                                : "text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"
-                        }`}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
                         aria-label={t("chat.share_location_label", { defaultValue: "Share Location" })}
                         title={t("chat.share_location_label", { defaultValue: "Share Location" })}
                     >
-                        {pendingLocationShare ? (
-                            <X className="h-5 w-5" />
-                        ) : (
-                            <MapPin className="h-5 w-5" />
-                        )}
+                        <MapPin className="h-5 w-5" />
                     </button>
                     <button
                         type="button"

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -16,7 +16,10 @@ import {
 	PencilLine,
 	Pin,
 	Reply,
+	RotateCw,
+	SendHorizontal,
 	Share2,
+	SquareCenterlineDashedHorizontal,
 	SquareStack,
 	TimerOff,
 	Trash2,
@@ -25,7 +28,9 @@ import {
 	X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import ReactCrop, { type Crop, type PixelCrop } from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
 import type { NavigateFunction } from "react-router-dom";
 import toast from "react-hot-toast";
 import { appLog } from "../../../utils/logger";
@@ -57,6 +62,8 @@ import { ChatThreadMessages } from "./ChatThreadMessages";
 import { ConfirmDialog } from "../../../components/ui/confirm-dialog";
 import { useApiFunctions } from "../../../hooks/useApiFunctions";
 import { isChatGhosted, toggleChatGhost } from "../../../utils/privacy";
+import { ToggleRow } from "../../../components/ui/toggle-row";
+import { BottomDrawer } from "../../../components/ui/bottom-drawer";
 import {
 	loadSavedPhrases,
 	SAVED_PHRASES_UPDATED_EVENT,
@@ -128,6 +135,7 @@ type ChatThreadPanelProps = {
 	setAttachmentLooping: (value: boolean) => void;
 	setAttachmentTakenOnGrindr: (value: boolean) => void;
 	confirmPendingAttachment: () => void;
+	confirmAttachmentFile: (file: File) => void | Promise<void>;
 	cancelPendingAttachment: () => void;
 	isAlbumPickerOpen: boolean;
 	isLoadingAlbums: boolean;
@@ -174,6 +182,11 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 	const { unitsPreset, geohash } = usePreferences();
 	const [selectedExpirationType, setSelectedExpirationType] = useState("INDEFINITE");
 	const [pendingLocationShare, setPendingLocationShare] = useState<{ lat: number; lon: number } | null>(null);
+	const [attachmentPreviewUrl, setAttachmentPreviewUrl] = useState<string | null>(null);
+	const [attachmentCrop, setAttachmentCrop] = useState<Crop | undefined>(undefined);
+	const [attachmentCompletedCrop, setAttachmentCompletedCrop] = useState<PixelCrop | undefined>(undefined);
+	const [isDraggingAttachmentCrop, setIsDraggingAttachmentCrop] = useState(false);
+	const attachmentImgRef = useRef<HTMLImageElement | null>(null);
 	const [mobileKeyboardInset, setMobileKeyboardInset] = useState(0);
 	const [isBlockConfirmOpen, setIsBlockConfirmOpen] = useState(false);
 	const [isDeleteConversationConfirmOpen, setIsDeleteConversationConfirmOpen] =
@@ -185,31 +198,6 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		}
 		return localStorage.getItem(SKIP_BLOCK_CONFIRM_KEY) === "true";
 	});
-
-	const [savedPhrases, setSavedPhrases] = useState<string[]>(() => loadSavedPhrases());
-
-	const handleUsePhrase = (phrase: string) => {
-		setDraft(draft ? `${draft} ${phrase}` : phrase);
-	};
-
-	useEffect(() => {
-		const syncSavedPhrases = (event: Event) => {
-			const detail = (event as CustomEvent<string[]>).detail;
-			if (Array.isArray(detail)) {
-				setSavedPhrases(detail);
-				return;
-			}
-			setSavedPhrases(loadSavedPhrases());
-		};
-
-		window.addEventListener(SAVED_PHRASES_UPDATED_EVENT, syncSavedPhrases as EventListener);
-		window.addEventListener("storage", syncSavedPhrases);
-
-		return () => {
-			window.removeEventListener(SAVED_PHRASES_UPDATED_EVENT, syncSavedPhrases as EventListener);
-			window.removeEventListener("storage", syncSavedPhrases);
-		};
-	}, []);
 
 	const {
 		navigate,
@@ -275,7 +263,8 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		attachmentTakenOnGrindr,
 		setAttachmentLooping,
 		setAttachmentTakenOnGrindr,
-		confirmPendingAttachment,
+		confirmPendingAttachment: _confirmPendingAttachment,
+		confirmAttachmentFile,
 		cancelPendingAttachment,
 		isAlbumPickerOpen,
 		isLoadingAlbums,
@@ -308,6 +297,123 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		onDeleteDrawerMedia,
 		onSendLocation,
 	} = props;
+
+    const [savedPhrases, setSavedPhrases] = useState<string[]>(() => loadSavedPhrases());
+
+	useEffect(() => {
+		if (!pendingAttachmentFile) {
+			setAttachmentPreviewUrl(null);
+			setAttachmentCrop(undefined);
+			setAttachmentCompletedCrop(undefined);
+			return;
+		}
+		const url = URL.createObjectURL(pendingAttachmentFile);
+		setAttachmentPreviewUrl(url);
+		setAttachmentCrop(undefined);
+		setAttachmentCompletedCrop(undefined);
+		return () => URL.revokeObjectURL(url);
+	}, [pendingAttachmentFile]);
+
+	useEffect(() => {
+		if (!attachmentPreviewUrl) return;
+		setAttachmentCrop({ unit: "%", x: 0, y: 0, width: 100, height: 100 });
+	}, [attachmentPreviewUrl]);
+
+	const applyAttachmentTransform = useCallback(async (type: "flipH" | "rotateCw") => {
+		const img = attachmentImgRef.current;
+		if (!img || !img.complete || img.naturalWidth === 0) return;
+		const sw = img.naturalWidth;
+		const sh = img.naturalHeight;
+		const canvas = document.createElement("canvas");
+		canvas.width = type === "rotateCw" ? sh : sw;
+		canvas.height = type === "rotateCw" ? sw : sh;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+		ctx.translate(canvas.width / 2, canvas.height / 2);
+		if (type === "flipH") ctx.scale(-1, 1);
+		if (type === "rotateCw") ctx.rotate(Math.PI / 2);
+		ctx.drawImage(img, -sw / 2, -sh / 2, sw, sh);
+		const blob = await new Promise<Blob | null>((resolve) =>
+			canvas.toBlob(resolve, "image/jpeg", 0.95),
+		);
+		if (!blob) return;
+		setAttachmentPreviewUrl((prev) => {
+			if (prev) URL.revokeObjectURL(prev);
+			return URL.createObjectURL(blob);
+		});
+	}, []);
+
+	const handleConfirmAttachment = useCallback(async () => {
+		if (!pendingAttachmentFile) return;
+		let fileToUpload: File = pendingAttachmentFile;
+		const isFullImage =
+			!attachmentCompletedCrop ||
+			!attachmentImgRef.current ||
+			(attachmentCompletedCrop.x <= 1 &&
+				attachmentCompletedCrop.y <= 1 &&
+				Math.abs(attachmentCompletedCrop.width - attachmentImgRef.current.width) <= 2 &&
+				Math.abs(attachmentCompletedCrop.height - attachmentImgRef.current.height) <= 2);
+		if (!isFullImage && attachmentCompletedCrop?.width && attachmentCompletedCrop.height && attachmentImgRef.current) {
+			const img = attachmentImgRef.current;
+			const scaleX = img.naturalWidth / img.width;
+			const scaleY = img.naturalHeight / img.height;
+			const canvas = document.createElement("canvas");
+			canvas.width = Math.round(attachmentCompletedCrop.width * scaleX);
+			canvas.height = Math.round(attachmentCompletedCrop.height * scaleY);
+			const ctx = canvas.getContext("2d");
+			if (ctx) {
+				ctx.drawImage(
+					img,
+					attachmentCompletedCrop.x * scaleX,
+					attachmentCompletedCrop.y * scaleY,
+					attachmentCompletedCrop.width * scaleX,
+					attachmentCompletedCrop.height * scaleY,
+					0,
+					0,
+					canvas.width,
+					canvas.height,
+				);
+				fileToUpload = await new Promise<File>((resolve) => {
+					canvas.toBlob(
+						(blob) => {
+							if (!blob) { resolve(pendingAttachmentFile); return; }
+							resolve(new File([blob], pendingAttachmentFile.name, { type: pendingAttachmentFile.type || "image/jpeg" }));
+						},
+						pendingAttachmentFile.type || "image/jpeg",
+						0.92,
+					);
+				});
+			}
+		}
+		await confirmAttachmentFile(fileToUpload);
+	}, [pendingAttachmentFile, attachmentCompletedCrop, confirmAttachmentFile]);
+
+	const handleUsePhrase = (phrase: string) => {
+		setDraft(draft ? `${draft} ${phrase}` : phrase);
+	};
+
+	useEffect(() => {
+		const syncSavedPhrases = (event: Event) => {
+			const detail = (event as CustomEvent<string[]>).detail;
+			if (Array.isArray(detail)) {
+				setSavedPhrases(detail);
+				return;
+			}
+			setSavedPhrases(loadSavedPhrases());
+		};
+
+		window.addEventListener(SAVED_PHRASES_UPDATED_EVENT, syncSavedPhrases as EventListener);
+		window.addEventListener("storage", syncSavedPhrases);
+
+		return () => {
+			window.removeEventListener(SAVED_PHRASES_UPDATED_EVENT, syncSavedPhrases as EventListener);
+			window.removeEventListener("storage", syncSavedPhrases);
+		};
+	}, []);
+    
+    const filteredPhrases = savedPhrases.filter((phrase) =>
+        draft.trim() === "" || phrase.toLowerCase().startsWith(draft.toLowerCase()),
+    );
 
     const [showGhostButton] = useState(() => window.localStorage.getItem("fg-show-ghost-btn") !== "false");
     const [isGhosted, setIsGhosted] = useState(true);
@@ -353,14 +459,9 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 	};
 
 	const onFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-		if (pendingLocationShare) {
-			void onSendLocation(pendingLocationShare.lat, pendingLocationShare.lon);
-			setPendingLocationShare(null);
-		} else {
-			handleSend(event);
-		}
-	};
+        event.preventDefault();
+        handleSend(event);
+    };
 
 	const handleCopy = async (message: UiMessage) => {
 		const location = getMessageLocation(message);
@@ -996,79 +1097,22 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								: undefined
 						}
 					>
-						<div className="mb-2 flex flex-wrap items-center gap-2">
-							<button
-								type="button"
-								onClick={() => {
-									toggleAlbumPicker();
-									if (isDrawerOpen) toggleDrawer();
-									if (pendingLocationShare) handleLocationShareRequest();
-								}}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-								aria-label={t("chat.share_album_label")}
-								title={t("chat.share_album_label")}
+						{(isUploadingAttachment || uploadProgress > 0) && (
+							<div
+								className="h-0.5 bg-[var(--surface-2)] mb-3"
+								style={{ marginTop: "-12px", marginLeft: "calc(-1 * var(--app-px))", marginRight: "calc(-1 * var(--app-px))" }}
 							>
-								<Share2 className="h-4 w-4" />
-							</button>
-							<button
-								type="button"
-								onClick={() => {
-									attachmentInputRef.current?.click();
-									if (isDrawerOpen) toggleDrawer();
-									if (pendingLocationShare) handleLocationShareRequest();
-								}}
-								disabled={isUploadingAttachment}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
-								aria-label={t("chat.attach_media")}
-								title={t("chat.attach_media")}
-							>
-								<ImagePlus className="h-4 w-4" />
-							</button>
-							<button
-								type="button"
-								onClick={() => {
-									toggleDrawer();
-									if (pendingLocationShare) handleLocationShareRequest();
-								}}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-								aria-label={t("chat.drawer_label")}
-								title={t("chat.drawer_label")}
-							>
-								<SquareStack className="h-4 w-4" />
-							</button>
-							<button
-								type="button"
-								onClick={() => {
-									handleLocationShareRequest();
-									if (isDrawerOpen) toggleDrawer();
-								}}
-								className={`inline-flex h-9 w-9 items-center justify-center rounded-xl border transition ${
-									pendingLocationShare
-										? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
-										: "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"
-								}`}
-								aria-label={t("chat.share_location_label", { defaultValue: "Share Location" })}
-								title={t("chat.share_location_label", { defaultValue: "Share Location" })}
-							>
-								{pendingLocationShare ? (
-									<X className="h-4 w-4" />
-								) : (
-									<MapPin className="h-4 w-4" />
-								)}
-							</button>
-
-							<input
-								type="file"
-								ref={attachmentInputRef}
-								onChange={onAttachmentInput}
-								accept="image/*,video/*"
-								className="hidden"
-							/>
-
-							{/* --- QUICK PHRASE PILLS --- */}
-							{savedPhrases.length > 0 && (
+								<div
+									className="h-0.5 bg-[var(--accent)] transition-all duration-300"
+									style={{ width: `${Math.min(100, uploadProgress)}%` }}
+								/>
+							</div>
+						)}
+						<div className="flex items-end gap-2 mb-2">
+                            {/* --- QUICK PHRASE PILLS --- */}
+							{filteredPhrases.length > 0 && (
 								<div className="flex flex-1 items-center gap-2 overflow-x-auto pb-1 -mb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-									{savedPhrases.map((phrase, idx) => (
+									{filteredPhrases.map((phrase, idx) => (
 										<button
 											key={idx}
 											type="button"
@@ -1081,74 +1125,132 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								</div>
 							)}
 							{/* -------------------------- */}
+                        </div>
+
+                        {replyTargetMessage ? (
+							<div className="mb-2 overflow-hidden rounded-2xl border border-[color-mix(in_srgb,var(--accent)_24%,var(--border))] bg-[color-mix(in_srgb,var(--surface-2)_82%,var(--accent)_8%)] shadow-[0_2px_10px_rgba(0,0,0,0.08)]">
+								<div className="flex items-stretch">
+									<div className="w-1 shrink-0 bg-[var(--accent)]" aria-hidden="true" />
+									<div className="flex min-w-0 flex-1 items-start justify-between gap-2 px-3 py-2.5">
+										<div className="min-w-0">
+											<p className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold text-[var(--text-muted)]">
+												<Reply className="h-3 w-3" />
+												<span>
+													{`${t("chat.actions.reply", { defaultValue: "Reply" })} · ${
+														userId != null && Number(replyTargetMessage.senderId) === Number(userId)
+															? t("chat.you")
+															: (selectedConversation.data.name?.trim() || t("chat.unknown"))
+													}`}
+												</span>
+											</p>
+											<div className="rounded-lg border border-[var(--border)]/80 bg-[var(--surface)]/85 px-2 py-1.5">
+												<p className="max-h-10 overflow-hidden text-xs leading-5 text-[var(--text)]">
+													{getMessagePreviewLabel(replyTargetMessage, t)}
+												</p>
+											</div>
+										</div>
+										<button
+											type="button"
+											onClick={clearReplyTarget}
+											className="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+											aria-label={t("chat.actions.cancel")}
+											title={t("chat.actions.cancel")}
+										>
+											<X className="h-3.5 w-3.5" />
+										</button>
+									</div>
+								</div>
+							</div>
+						) : null}
+
+						<div className="flex items-end gap-2 mb-2">
+							<textarea
+								value={draft}
+								onChange={(event) => setDraft(event.target.value)}
+								rows={1}
+								maxLength={1000}
+								placeholder={t("chat.write_message")}
+								className="input-field resize-none disabled:opacity-60"
+                                style={{ fieldSizing: "content", maxHeight: "115px" }}
+							/>
+							<button
+								type="submit"
+								disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
+								className="btn-accent self-stretch shrink-0 px-4 text-sm"
+							>
+								<SendHorizontal className="h-4 w-4" />
+							</button>
 						</div>
 
-						{pendingLocationShare ? (
-							<div className="mb-2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface-2)]">
-								<div className="p-3">
-									<p className="text-xs font-medium text-[var(--text)]">
-										{t("chat.share_location_confirm", { defaultValue: "Share this location?" })}
-									</p>
-								</div>
-								<div className="h-64 w-full border-t border-[var(--border)]">
-									<LeafletLocationPicker
-										selectedLocation={pendingLocationShare}
-										onPick={(lat, lon) => setPendingLocationShare({ lat, lon })}
-										onError={(msg) => toast.error(msg)}
-										className="h-full w-full"
-										defaultZoom={18}
-									/>
-								</div>
-							</div>
-						) : null}
+                        <div className="mb-2 mx-5 flex items-center justify-between gap-2">
+							<button
+								type="button"
+								onClick={() => {
+									toggleAlbumPicker();
+									if (isDrawerOpen) toggleDrawer();
+									if (pendingLocationShare) handleLocationShareRequest();
+								}}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+								aria-label={t("chat.share_album_label")}
+								title={t("chat.share_album_label")}
+							>
+								<Share2 className="h-5 w-5" />
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									attachmentInputRef.current?.click();
+									if (isDrawerOpen) toggleDrawer();
+									if (pendingLocationShare) handleLocationShareRequest();
+								}}
+								disabled={isUploadingAttachment}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+								aria-label={t("chat.attach_media")}
+								title={t("chat.attach_media")}
+							>
+								<ImagePlus className="h-5 w-5" />
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									toggleDrawer();
+									if (pendingLocationShare) handleLocationShareRequest();
+								}}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+								aria-label={t("chat.drawer_label")}
+								title={t("chat.drawer_label")}
+							>
+								<SquareStack className="h-5 w-5" />
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									handleLocationShareRequest();
+									if (isDrawerOpen) toggleDrawer();
+								}}
+								className={`inline-flex h-9 w-9 items-center justify-center rounded-xl transition ${
+									pendingLocationShare
+										? "bg-[var(--accent)] text-[var(--accent-contrast)]"
+										: "text-[var(--text-muted)] hover:text-[var(--text)]"
+								}`}
+								aria-label={t("chat.share_location_label", { defaultValue: "Share Location" })}
+								title={t("chat.share_location_label", { defaultValue: "Share Location" })}
+							>
+								{pendingLocationShare ? (
+									<X className="h-5 w-5" />
+								) : (
+									<MapPin className="h-5 w-5" />
+								)}
+							</button>
 
-						{pendingAttachmentFile ? (
-							<div className="mb-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-3">
-								<p className="text-xs font-medium text-[var(--text)]">
-									{t("chat.attachments.ready_to_send", { file: pendingAttachmentFile.name })}
-								</p>
-								<div className="mt-2 grid gap-2">
-									<label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-										<input
-											type="checkbox"
-											checked={attachmentLooping}
-											onChange={(event) =>
-												setAttachmentLooping(event.target.checked)
-											}
-										/>
-										<span>{t("chat.attachments.looping")}</span>
-									</label>
-									<label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-										<input
-											type="checkbox"
-											checked={attachmentTakenOnGrindr}
-											onChange={(event) =>
-												setAttachmentTakenOnGrindr(event.target.checked)
-											}
-										/>
-										<span>{t("chat.attachments.taken_on_grindr")}</span>
-									</label>
-								</div>
-								<div className="mt-3 flex gap-2">
-									<button
-										type="button"
-										onClick={confirmPendingAttachment}
-										disabled={isUploadingAttachment}
-										className="rounded-md border border-[var(--border)] px-2 py-1 text-[11px]"
-									>
-										{t("chat.attachments.send_attachment")}
-									</button>
-									<button
-										type="button"
-										onClick={cancelPendingAttachment}
-										disabled={isUploadingAttachment}
-										className="rounded-md border border-[var(--border)] px-2 py-1 text-[11px] text-[var(--text-muted)]"
-									>
-										{t("chat.actions.cancel")}
-									</button>
-								</div>
-							</div>
-						) : null}
+							<input
+								type="file"
+								ref={attachmentInputRef}
+								onChange={onAttachmentInput}
+								accept="image/*,video/*"
+								className="hidden"
+							/>
+						</div>
 
 						{isAlbumPickerOpen ? (
 							<div className="mb-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-2">
@@ -1190,76 +1292,92 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							</div>
 						) : null}
 
-						{isUploadingAttachment || uploadProgress > 0 ? (
-							<div className="mb-2">
-								<div className="mb-1 flex justify-between text-[11px] text-[var(--text-muted)]">
-									<span>{t("chat.attachments.uploading")}</span>
-									<span>{Math.round(uploadProgress)}%</span>
-								</div>
-								<div className="h-2 rounded-full bg-[var(--surface-2)]">
-									<div
-										className="h-2 rounded-full bg-[var(--accent)] transition-all"
-										style={{ width: `${Math.min(100, uploadProgress)}%` }}
-									/>
-								</div>
-							</div>
-						) : null}
+					</form>
 
-						{replyTargetMessage ? (
-							<div className="mb-2 overflow-hidden rounded-2xl border border-[color-mix(in_srgb,var(--accent)_24%,var(--border))] bg-[color-mix(in_srgb,var(--surface-2)_82%,var(--accent)_8%)] shadow-[0_2px_10px_rgba(0,0,0,0.08)]">
-								<div className="flex items-stretch">
-									<div className="w-1 shrink-0 bg-[var(--accent)]" aria-hidden="true" />
-									<div className="flex min-w-0 flex-1 items-start justify-between gap-2 px-3 py-2.5">
-										<div className="min-w-0">
-											<p className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold text-[var(--text-muted)]">
-												<Reply className="h-3 w-3" />
-												<span>
-													{`${t("chat.actions.reply", { defaultValue: "Reply" })} · ${
-														userId != null && Number(replyTargetMessage.senderId) === Number(userId)
-															? t("chat.you")
-															: (selectedConversation.data.name?.trim() || t("chat.unknown"))
-													}`}
-												</span>
-											</p>
-											<div className="rounded-lg border border-[var(--border)]/80 bg-[var(--surface)]/85 px-2 py-1.5">
-												<p className="max-h-10 overflow-hidden text-xs leading-5 text-[var(--text)]">
-													{getMessagePreviewLabel(replyTargetMessage, t)}
-												</p>
+					{pendingAttachmentFile ? (
+						<BottomDrawer
+							title={t("chat.attachments.ready_to_send", { file: pendingAttachmentFile.name })}
+							onClose={cancelPendingAttachment}
+							onConfirm={() => void handleConfirmAttachment()}
+							confirmLabel={t("chat.attachments.send_attachment")}
+							cancelLabel={t("chat.actions.cancel")}
+							isProcessing={isUploadingAttachment}
+						>
+							{attachmentPreviewUrl && (
+								pendingAttachmentFile.type.startsWith("video/") ? (
+									<div className="px-3 pb-3">
+										<video src={attachmentPreviewUrl} controls className="w-full object-contain rounded-xl border border-[var(--border)]" style={{ maxHeight: "40dvh" }} />
+									</div>
+								) : (
+									<div className="px-3 pb-3">
+										<div className="flex justify-center">
+											<style>{`
+												@keyframes attach-logo-shine { 0%, 100% { filter: drop-shadow(0 0 2px rgba(255,140,0,0.3)) brightness(1); } 50% { filter: drop-shadow(0 0 7px rgba(255,140,0,0.95)) brightness(1.25); } }
+												.attach-logo-shine { animation: attach-logo-shine 2.8s ease-in-out infinite; }
+												.attach-crop .ReactCrop__crop-mask { display: none !important; } .attach-crop .ReactCrop__crop-selection { background-image: none !important; animation: none !important; outline: none !important; border: 3px solid rgba(255,255,255,0.6) !important; border-radius: 11px !important; box-shadow: 0 0 0 9999px rgba(0,0,0,0.5) !important; }
+												.attach-crop .ord-n, .attach-crop .ord-s, .attach-crop .ord-e, .attach-crop .ord-w { display: none !important; }
+												.attach-crop .ReactCrop__drag-handle { background: transparent !important; border: none !important; width: 15px !important; height: 15px !important; }
+												.attach-crop .ord-nw { transform: translate(4px, 4px) !important; border-top: 2px solid white !important; border-left: 2px solid white !important; border-top-left-radius: 4px !important; }
+												.attach-crop .ord-ne { transform: translate(-4px, 4px) !important; border-top: 2px solid white !important; border-right: 2px solid white !important; border-top-right-radius: 4px !important; }
+												.attach-crop .ord-sw { transform: translate(4px, -4px) !important; border-bottom: 2px solid white !important; border-left: 2px solid white !important; border-bottom-left-radius: 4px !important; }
+												.attach-crop .ord-se { transform: translate(-4px, -4px) !important; border-bottom: 2px solid white !important; border-right: 2px solid white !important; border-bottom-right-radius: 4px !important; }
+											`}</style>
+											<div className="relative rounded-xl border border-[var(--border)] overflow-hidden">
+											<ReactCrop
+												crop={attachmentCrop}
+												onChange={(c) => { setIsDraggingAttachmentCrop(true); setAttachmentCrop(c); }}
+												onComplete={(c) => { setIsDraggingAttachmentCrop(false); setAttachmentCompletedCrop(c); }}
+												ruleOfThirds={isDraggingAttachmentCrop}
+												minWidth={150}
+												minHeight={150}
+												className="attach-crop ReactCrop--no-animate"
+												style={{ maxHeight: "45dvh", display: "block" }}
+											>
+												<img ref={attachmentImgRef} src={attachmentPreviewUrl} alt="Preview" className="block" style={{ maxHeight: "45dvh" }} />
+											</ReactCrop>
+											{attachmentTakenOnGrindr && attachmentCrop && (
+												<div
+													className="absolute inline-flex items-center gap-1.5 pointer-events-none"
+													style={{
+														left: `calc(${attachmentCrop.unit === "%" ? attachmentCrop.x + "%" : attachmentCrop.x + "px"} + 10px)`,
+														top: `calc(${attachmentCrop.unit === "%" ? (attachmentCrop.y + attachmentCrop.height) + "%" : (attachmentCrop.y + attachmentCrop.height) + "px"} - 10px)`,
+														transform: "translateY(-100%)",
+													}}
+												>
+													<img src={freegrindLogo} alt="" className="h-5 w-5 rounded-full attach-logo-shine" />
+													<span className="inline-flex items-center gap-1 rounded-full bg-black/65 px-2 py-1 text-[10px] font-semibold text-white">
+														<span>{t("chat.time.just_now", { defaultValue: "just now" })}</span>
+													</span>
+												</div>
+											)}
 											</div>
 										</div>
-										<button
-											type="button"
-											onClick={clearReplyTarget}
-											className="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
-											aria-label={t("chat.actions.cancel")}
-											title={t("chat.actions.cancel")}
-										>
-											<X className="h-3.5 w-3.5" />
-										</button>
+										<div className="mt-3 flex items-center justify-center gap-8">
+											<button type="button" onClick={() => void applyAttachmentTransform("flipH")} className="text-[var(--text-muted)] transition hover:text-[var(--text)]" aria-label="Flip horizontal">
+												<SquareCenterlineDashedHorizontal className="h-6 w-6" />
+											</button>
+											<button type="button" onClick={() => void applyAttachmentTransform("rotateCw")} className="text-[var(--text-muted)] transition hover:text-[var(--text)]" aria-label="Rotate clockwise">
+												<RotateCw className="h-6 w-6" />
+											</button>
+										</div>
 									</div>
-								</div>
+								)
+							)}
+							<div className="px-3 pb-3 grid gap-3">
+								<ToggleRow
+                                    checked={attachmentLooping}
+                                    onChange={setAttachmentLooping}
+                                    label={t("chat.attachments.looping")}
+                                />
+                                <ToggleRow
+                                    checked={attachmentTakenOnGrindr}
+                                    onChange={setAttachmentTakenOnGrindr}
+                                    label={t("chat.attachments.taken_on_grindr")}
+                                    description={t("chat.attachments.taken_on_grindr_description")}
+                                />
 							</div>
-						) : null}
-
-						<div className="flex items-end gap-2">
-							<textarea
-								value={draft}
-								onChange={(event) => setDraft(event.target.value)}
-								rows={2}
-								maxLength={1000}
-								placeholder={t("chat.write_message")}
-								disabled={!!pendingLocationShare}
-								className="input-field min-h-[56px] resize-none disabled:opacity-60"
-							/>
-							<button
-								type="submit"
-								disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
-								className="btn-accent self-stretch shrink-0 px-4 text-sm"
-							>
-								{isSending ? t("chat.sending") : t("chat.send")}
-							</button>
-						</div>
-					</form>
+						</BottomDrawer>
+					) : null}
 
 					{isDrawerOpen ? (
 						<ChatDrawerPanel
@@ -1277,6 +1395,31 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							isDesktop={isDesktop}
 						/>
 					) : null}
+
+                    {pendingLocationShare ? (
+						<BottomDrawer
+							title={t("chat.share_location_confirm", { defaultValue: "Share this location?" })}
+							onClose={() => setPendingLocationShare(null)}
+							onConfirm={() => {
+								void onSendLocation(pendingLocationShare.lat, pendingLocationShare.lon);
+								setPendingLocationShare(null);
+							}}
+							confirmLabel={t("chat.send")}
+							cancelLabel={t("chat.actions.cancel")}
+						>
+							<div className="px-3 pb-3">
+								<div className="overflow-hidden rounded-xl border border-[var(--border)]" style={{ height: "40dvh" }}>
+									<LeafletLocationPicker
+										selectedLocation={pendingLocationShare}
+										onPick={(lat, lon) => setPendingLocationShare({ lat, lon })}
+										onError={(msg) => toast.error(msg)}
+										className="h-full w-full"
+										defaultZoom={18}
+									/>
+								</div>
+							</div>
+						</BottomDrawer>
+                    ) : null}
 
 					{!isDesktop && selectedActionMessage && albumViewer === null ? (
 						<div
@@ -1404,25 +1547,34 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 
 					{pendingAlbumShare && albumViewer === null ? (
 						<div
-							className={`fixed inset-0 z-[60] flex items-end justify-center bg-black/45 p-4 backdrop-blur-sm no-touch-callout ${
-								isDesktop ? "pb-32" : ""
-							}`}
+							className="fixed inset-0 z-[60] flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout"
 							onClick={isSharingAlbum ? undefined : handlePendingAlbumShareBackdropClose}
 						>
 							<div
 								role="dialog"
 								aria-modal="true"
 								aria-labelledby="chat-album-share-confirm-title"
-								className="w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] p-4 shadow-2xl"
+								className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden mx-3"
 								onClick={(event) => event.stopPropagation()}
 							>
-								<p
-									id="chat-album-share-confirm-title"
-									className="text-sm font-semibold text-[var(--text)]"
-								>
-									{t("chat.share_album_label")}
-								</p>
-								<p className="mt-2 text-sm leading-relaxed text-[var(--text-muted)]">
+								<div className="flex items-center justify-between px-4 py-3">
+									<p
+										id="chat-album-share-confirm-title"
+										className="text-sm font-semibold text-[var(--text)]"
+									>
+										{t("chat.share_album_label")}
+									</p>
+									<button
+										type="button"
+										onClick={closePendingAlbumShare}
+										disabled={isSharingAlbum}
+										className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
+									>
+										<X className="h-4 w-4" />
+									</button>
+								</div>
+								<div className="px-4 pb-3">
+								<p className="text-sm leading-relaxed text-[var(--text-muted)]">
 									{t("chat.confirm_share_album", {
 										album: pendingAlbumShare.albumName,
 									})}
@@ -1455,12 +1607,13 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 									</div>
 								</div>
 
-								<div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+								</div>
+								<div className="flex gap-2 p-3" style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}>
 									<button
 										type="button"
 										onClick={closePendingAlbumShare}
 										disabled={isSharingAlbum}
-										className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+										className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
 									>
 										{t("chat.actions.cancel")}
 									</button>
@@ -1468,12 +1621,13 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 										type="button"
 										onClick={() => void confirmPendingAlbumShare(selectedExpirationType)}
 										disabled={isSharingAlbum}
-										className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+										className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
 									>
 										{isSharingAlbum ? (
-											<Loader2 className="h-4 w-4 animate-spin" />
-										) : null}
-										<span>{t("chat.share")}</span>
+											<Loader2 className="mx-auto h-4 w-4 animate-spin" />
+										) : (
+											<span>{t("chat.share")}</span>
+										)}
 									</button>
 								</div>
 							</div>
@@ -1569,7 +1723,52 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                         : undefined
                 }
             >
-				<div className="mb-2 flex flex-wrap items-center gap-2">
+				{(isUploadingAttachment || uploadProgress > 0) && (
+					<div className="absolute top-0 left-0 right-0 h-0.5 bg-[var(--surface-2)]">
+						<div
+							className="h-0.5 bg-[var(--accent)] transition-all duration-300"
+							style={{ width: `${Math.min(100, uploadProgress)}%` }}
+						/>
+					</div>
+				)}
+                <div className="flex items-end gap-2 mb-2">
+                    {/* --- QUICK PHRASE PILLS --- */}
+                    {filteredPhrases.length > 0 && (
+                        <div className="flex flex-1 items-center gap-2 overflow-x-auto pb-1 -mb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                            {filteredPhrases.map((phrase, idx) => (
+                                <button
+                                    key={idx}
+                                    type="button"
+                                    onClick={() => handleUsePhrase(phrase)}
+                                    className="shrink-0 whitespace-nowrap rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)] active:scale-95"
+                                >
+                                    {phrase}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                    {/* -------------------------- */}
+                </div>
+                <div className="flex items-end gap-2 mb-2">
+					<textarea
+						value={draft}
+						onChange={(event) => setDraft(event.target.value)}
+						rows={1}
+						maxLength={1000}
+						placeholder={t("chat.new_conversation.write_first_message")}
+						className="input-field resize-none disabled:opacity-60"
+                        style={{ fieldSizing: "content", maxHeight: "115px" }}
+					/>
+					<button
+						type="submit"
+						disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
+						className="btn-accent self-stretch shrink-0 px-4 text-sm"
+					>
+						{isSending ? t("chat.sending") : t("chat.send")}
+					</button>
+				</div>
+
+				<div className="mb-2 mx-5 flex items-center justify-between gap-2">
                     <button
                         type="button"
                         onClick={() => {
@@ -1577,11 +1776,11 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							if (isDrawerOpen) toggleDrawer();
 							if (pendingLocationShare) handleLocationShareRequest();
 						}}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)]"
                         aria-label={t("chat.share_album_label")}
                         title={t("chat.share_album_label")}
                     >
-                        <Share2 className="h-4 w-4" />
+                        <Share2 className="h-5 w-5" />
                     </button>
                     <button
                         type="button"
@@ -1591,20 +1790,20 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							if (pendingLocationShare) handleLocationShareRequest();
 						}}
                         disabled={isUploadingAttachment}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
                         aria-label={t("chat.attach_media")}
                         title={t("chat.attach_media")}
                     >
-                        <ImagePlus className="h-4 w-4" />
+                        <ImagePlus className="h-5 w-5" />
                     </button>
                     <button
                         type="button"
                         disabled
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] text-[var(--text-muted)] opacity-40 cursor-not-allowed"
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] opacity-40 cursor-not-allowed"
                         aria-label={t("chat.drawer_label")}
                         title={t("chat.drawer_unavailable", { defaultValue: "Send a message first to use the drawer" })}
                     >
-                        <SquareStack className="h-4 w-4" />
+                        <SquareStack className="h-5 w-5" />
                     </button>
 					<button
                         type="button"
@@ -1612,113 +1811,29 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							handleLocationShareRequest();
 							if (isDrawerOpen) toggleDrawer();
 						}}
-                        className={`inline-flex h-9 w-9 items-center justify-center rounded-xl border transition ${
+                        className={`inline-flex h-9 w-9 items-center justify-center rounded-xl transition ${
                             pendingLocationShare
-                                ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-contrast)]"
-                                : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"
+                                ? "bg-[var(--accent)] text-[var(--accent-contrast)]"
+                                : "text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--text)]"
                         }`}
                         aria-label={t("chat.share_location_label", { defaultValue: "Share Location" })}
                         title={t("chat.share_location_label", { defaultValue: "Share Location" })}
                     >
                         {pendingLocationShare ? (
-                            <X className="h-4 w-4" />
+                            <X className="h-5 w-5" />
                         ) : (
-                            <MapPin className="h-4 w-4" />
+                            <MapPin className="h-5 w-5" />
                         )}
                     </button>
 
-							<input
-								type="file"
-								ref={attachmentInputRef}
-								onChange={onAttachmentInput}
-								accept="image/*,video/*"
-								className="hidden"
-							/>
-
-							{/* --- QUICK PHRASE PILLS --- */}
-							{savedPhrases.length > 0 && (
-								<div className="flex flex-1 items-center gap-2 overflow-x-auto pb-1 -mb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-									{savedPhrases.map((phrase, idx) => (
-										<button
-											key={idx}
-											type="button"
-											onClick={() => handleUsePhrase(phrase)}
-											className="shrink-0 whitespace-nowrap rounded-lg bg-[var(--surface-2)] border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)] active:scale-95"
-										>
-											{phrase}
-										</button>
-									))}
-								</div>
-							)}
-							{/* -------------------------- */}
-						</div>
-
-				{pendingLocationShare ? (
-					<div className="mb-2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface-2)]">
-						<div className="p-3">
-							<p className="text-xs font-medium text-[var(--text)]">
-								{t("chat.share_location_confirm", { defaultValue: "Share this location?" })}
-							</p>
-						</div>
-						<div className="h-64 w-full border-t border-[var(--border)]">
-							<LeafletLocationPicker
-								selectedLocation={pendingLocationShare}
-								onPick={(lat, lon) => setPendingLocationShare({ lat, lon })}
-								onError={(msg) => toast.error(msg)}
-								className="h-full w-full"
-								defaultZoom={18}
-							/>
-						</div>
-					</div>
-				) : null}
-
-				{pendingAttachmentFile ? (
-					<div className="mb-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-3">
-						<p className="text-xs font-medium text-[var(--text)]">
-							{t("chat.attachments.ready_to_send", { file: pendingAttachmentFile.name })}
-						</p>
-						<div className="mt-2 grid gap-2">
-							<label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-								<input
-									type="checkbox"
-									checked={attachmentLooping}
-									onChange={(event) =>
-										setAttachmentLooping(event.target.checked)
-									}
-								/>
-								<span>{t("chat.attachments.looping")}</span>
-							</label>
-							<label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-								<input
-									type="checkbox"
-									checked={attachmentTakenOnGrindr}
-									onChange={(event) =>
-										setAttachmentTakenOnGrindr(event.target.checked)
-									}
-								/>
-								<span>{t("chat.attachments.taken_on_grindr")}</span>
-							</label>
-						</div>
-						<div className="mt-3 flex gap-2">
-							<button
-								type="button"
-								onClick={confirmPendingAttachment}
-								disabled={isUploadingAttachment}
-								className="rounded-md border border-[var(--border)] px-2 py-1 text-[11px]"
-							>
-								{t("chat.attachments.send_attachment")}
-							</button>
-							<button
-								type="button"
-								onClick={cancelPendingAttachment}
-								disabled={isUploadingAttachment}
-								className="rounded-md border border-[var(--border)] px-2 py-1 text-[11px] text-[var(--text-muted)]"
-							>
-								{t("chat.actions.cancel")}
-							</button>
-						</div>
-					</div>
-				) : null}
+                    <input
+                        type="file"
+                        ref={attachmentInputRef}
+                        onChange={onAttachmentInput}
+                        accept="image/*,video/*"
+                        className="hidden"
+                    />
+                </div>
 
                 {isAlbumPickerOpen ? (
                     <div className="mb-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-2">
@@ -1760,62 +1875,148 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                     </div>
                 ) : null}
 
-				{isUploadingAttachment || uploadProgress > 0 ? (
-					<div className="mb-2">
-						<div className="mb-1 flex justify-between text-[11px] text-[var(--text-muted)]">
-							<span>{t("chat.attachments.uploading")}</span>
-							<span>{Math.round(uploadProgress)}%</span>
-						</div>
-						<div className="h-2 rounded-full bg-[var(--surface-2)]">
-							<div
-								className="h-2 rounded-full bg-[var(--accent)] transition-all"
-								style={{ width: `${Math.min(100, uploadProgress)}%` }}
+			</form>
+
+			{pendingAttachmentFile ? (
+				<BottomDrawer
+					title={t("chat.attachments.ready_to_send", { file: pendingAttachmentFile.name })}
+					onClose={cancelPendingAttachment}
+					onConfirm={() => void handleConfirmAttachment()}
+					confirmLabel={t("chat.attachments.send_attachment")}
+					cancelLabel={t("chat.actions.cancel")}
+					isProcessing={isUploadingAttachment}
+				>
+					{attachmentPreviewUrl && (
+						pendingAttachmentFile.type.startsWith("video/") ? (
+							<div className="px-3 pb-3">
+								<video src={attachmentPreviewUrl} controls className="w-full object-contain rounded-xl border border-[var(--border)]" style={{ maxHeight: "40dvh" }} />
+							</div>
+						) : (
+							<div className="px-3 pb-3">
+								<div className="flex justify-center">
+									<style>{`
+										@keyframes attach-logo-shine { 0%, 100% { filter: drop-shadow(0 0 2px rgba(255,140,0,0.3)) brightness(1); } 50% { filter: drop-shadow(0 0 7px rgba(255,140,0,0.95)) brightness(1.25); } }
+										.attach-logo-shine { animation: attach-logo-shine 2.8s ease-in-out infinite; }
+										.attach-crop .ReactCrop__crop-mask { display: none !important; } .attach-crop .ReactCrop__crop-selection { background-image: none !important; animation: none !important; outline: none !important; border: 3px solid rgba(255,255,255,0.6) !important; border-radius: 11px !important; box-shadow: 0 0 0 9999px rgba(0,0,0,0.5) !important; }
+										.attach-crop .ord-n, .attach-crop .ord-s, .attach-crop .ord-e, .attach-crop .ord-w { display: none !important; }
+										.attach-crop .ReactCrop__drag-handle { background: transparent !important; border: none !important; width: 15px !important; height: 15px !important; }
+										.attach-crop .ord-nw { transform: translate(4px, 4px) !important; border-top: 2px solid white !important; border-left: 2px solid white !important; }
+										.attach-crop .ord-ne { transform: translate(-4px, 4px) !important; border-top: 2px solid white !important; border-right: 2px solid white !important; }
+										.attach-crop .ord-sw { transform: translate(4px, -4px) !important; border-bottom: 2px solid white !important; border-left: 2px solid white !important; }
+										.attach-crop .ord-se { transform: translate(-4px, -4px) !important; border-bottom: 2px solid white !important; border-right: 2px solid white !important; }
+									`}</style>
+									<div className="relative rounded-xl border border-[var(--border)] overflow-hidden">
+									<ReactCrop
+										crop={attachmentCrop}
+										onChange={(c) => { setIsDraggingAttachmentCrop(true); setAttachmentCrop(c); }}
+										onComplete={(c) => { setIsDraggingAttachmentCrop(false); setAttachmentCompletedCrop(c); }}
+										ruleOfThirds={isDraggingAttachmentCrop}
+										minWidth={150}
+										minHeight={150}
+										className="attach-crop ReactCrop--no-animate"
+										style={{ maxHeight: "45dvh", display: "block" }}
+									>
+										<img ref={attachmentImgRef} src={attachmentPreviewUrl} alt="Preview" className="block" style={{ maxHeight: "45dvh" }} />
+									</ReactCrop>
+									{attachmentTakenOnGrindr && attachmentCrop && (
+										<div
+											className="absolute inline-flex items-center gap-1.5 pointer-events-none"
+											style={{
+												left: `calc(${attachmentCrop.unit === "%" ? attachmentCrop.x + "%" : attachmentCrop.x + "px"} + 10px)`,
+												top: `calc(${attachmentCrop.unit === "%" ? (attachmentCrop.y + attachmentCrop.height) + "%" : (attachmentCrop.y + attachmentCrop.height) + "px"} - 10px)`,
+												transform: "translateY(-100%)",
+											}}
+										>
+											<img src={freegrindLogo} alt="" className="h-5 w-5 rounded-full attach-logo-shine" />
+											<span className="inline-flex items-center gap-1 rounded-full bg-black/65 px-2 py-1 text-[10px] font-semibold text-white">
+												<span>{t("chat.time.just_now", { defaultValue: "just now" })}</span>
+											</span>
+										</div>
+									)}
+									</div>
+								</div>
+								<div className="mt-3 flex items-center justify-center gap-8">
+									<button type="button" onClick={() => void applyAttachmentTransform("flipH")} className="text-[var(--text-muted)] transition hover:text-[var(--text)]" aria-label="Flip horizontal">
+										<SquareCenterlineDashedHorizontal className="h-6 w-6" />
+									</button>
+									<button type="button" onClick={() => void applyAttachmentTransform("rotateCw")} className="text-[var(--text-muted)] transition hover:text-[var(--text)]" aria-label="Rotate clockwise">
+										<RotateCw className="h-6 w-6" />
+									</button>
+								</div>
+							</div>
+						)
+					)}
+					<div className="px-3 pb-3 grid gap-3">
+						<ToggleRow 
+                            checked={attachmentLooping}
+                            onChange={setAttachmentLooping}
+                            label={t("chat.attachments.looping")}
+                        />
+                        <ToggleRow
+                            checked={attachmentTakenOnGrindr}
+                            onChange={setAttachmentTakenOnGrindr}
+                            label={t("chat.attachments.taken_on_grindr")}
+                            description={t("chat.attachments.taken_on_grindr_description")}
+                        />
+					</div>
+				</BottomDrawer>
+			) : null}
+
+			{pendingLocationShare ? (
+				<BottomDrawer
+					title={t("chat.share_location_confirm", { defaultValue: "Share this location?" })}
+					onClose={() => setPendingLocationShare(null)}
+					onConfirm={() => {
+						void onSendLocation(pendingLocationShare.lat, pendingLocationShare.lon);
+						setPendingLocationShare(null);
+					}}
+					confirmLabel={t("chat.send")}
+					cancelLabel={t("chat.actions.cancel")}
+				>
+					<div className="px-3 pb-3">
+						<div className="overflow-hidden rounded-xl border border-[var(--border)]" style={{ height: "40dvh" }}>
+							<LeafletLocationPicker
+								selectedLocation={pendingLocationShare}
+								onPick={(lat, lon) => setPendingLocationShare({ lat, lon })}
+								onError={(msg) => toast.error(msg)}
+								className="h-full w-full"
+								defaultZoom={18}
 							/>
 						</div>
 					</div>
-				) : null}
-
-				<div className="flex items-end gap-2">
-					<textarea
-						value={draft}
-						onChange={(event) => setDraft(event.target.value)}
-						rows={2}
-						maxLength={1000}
-						placeholder={t("chat.new_conversation.write_first_message")}
-						disabled={!!pendingLocationShare}
-						className="input-field min-h-[56px] resize-none disabled:opacity-60"
-					/>
-					<button
-						type="submit"
-						disabled={isSending || (!pendingLocationShare && draft.trim().length === 0)}
-						className="btn-accent self-stretch shrink-0 px-4 text-sm"
-					>
-						{isSending ? t("chat.sending") : t("chat.send")}
-					</button>
-				</div>
-			</form>
+				</BottomDrawer>
+			) : null}
 
             {pendingAlbumShare && albumViewer === null ? (
                 <div
-                    className={`fixed inset-0 z-[60] flex items-end justify-center bg-black/45 p-4 backdrop-blur-sm no-touch-callout ${
-                        isDesktop ? "pb-32" : ""
-                    }`}
+                    className="fixed inset-0 z-[60] flex flex-col justify-end bg-black/45 backdrop-blur-sm no-touch-callout"
                     onClick={isSharingAlbum ? undefined : handlePendingAlbumShareBackdropClose}
                 >
                     <div
                         role="dialog"
                         aria-modal="true"
                         aria-labelledby="chat-album-share-confirm-title"
-                        className="w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--surface)_92%,black_8%)] p-4 shadow-2xl"
+                        className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden mx-3"
                         onClick={(event) => event.stopPropagation()}
                     >
-                        <p
-                            id="chat-album-share-confirm-title"
-                            className="text-sm font-semibold text-[var(--text)]"
-                        >
-                            {t("chat.share_album_label")}
-                        </p>
-                        <p className="mt-2 text-sm leading-relaxed text-[var(--text-muted)]">
+                        <div className="flex items-center justify-between px-4 py-3">
+                            <p
+                                id="chat-album-share-confirm-title"
+                                className="text-sm font-semibold text-[var(--text)]"
+                            >
+                                {t("chat.share_album_label")}
+                            </p>
+                            <button
+                                type="button"
+                                onClick={closePendingAlbumShare}
+                                disabled={isSharingAlbum}
+                                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] transition hover:text-[var(--text)] disabled:opacity-40"
+                            >
+                                <X className="h-4 w-4" />
+                            </button>
+                        </div>
+                        <div className="px-4 pb-3">
+                        <p className="text-sm leading-relaxed text-[var(--text-muted)]">
                             {t("chat.confirm_share_album", {
                                 album: pendingAlbumShare.albumName,
                             })}
@@ -1848,12 +2049,13 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                             </div>
                         </div>
 
-                        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                        </div>
+                        <div className="flex gap-2 p-3" style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}>
                             <button
                                 type="button"
                                 onClick={closePendingAlbumShare}
                                 disabled={isSharingAlbum}
-                                className="inline-flex h-11 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
+                                className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-2.5 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--accent)] hover:text-[var(--text)] disabled:opacity-60"
                             >
                                 {t("chat.actions.cancel")}
                             </button>
@@ -1861,12 +2063,13 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                                 type="button"
                                 onClick={() => void confirmPendingAlbumShare(selectedExpirationType)}
                                 disabled={isSharingAlbum}
-                                className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
+                                className="flex-1 rounded-xl border border-[var(--accent)] bg-[var(--accent)] py-2.5 text-sm font-semibold text-[var(--accent-contrast)] transition hover:brightness-110 disabled:opacity-60"
                             >
                                 {isSharingAlbum ? (
-                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                ) : null}
-                                <span>{t("chat.share")}</span>
+                                    <Loader2 className="mx-auto h-4 w-4 animate-spin" />
+                                ) : (
+                                    <span>{t("chat.share")}</span>
+                                )}
                             </button>
                         </div>
                     </div>

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -110,7 +110,7 @@ type ChatThreadPanelProps = {
 	startMessageLongPress: (messageId: string) => void;
 	endMessageLongPress: () => void;
 	messageLongPressTriggeredRef: { current: boolean };
-	openFullScreenImage: (imageUrl: string) => void;
+	openFullScreenImage: (imageUrl: string, meta?: { takenOnGrindr: boolean; createdAtLabel: string | null; timestamp: number }) => void;
 	openAlbumViewerById: (albumId: number) => void | Promise<void>;
 	selectedThreadMessageMatches: Array<{ messageId: string }>;
 	activeThreadSearchIndex: number;

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -177,6 +177,7 @@ type ChatThreadPanelProps = {
 	selectedActionMessage: UiMessage | null;
 	selectedActionMessageMine: boolean;
 	albumViewer: AlbumViewerState | null;
+	onCloseAlbumViewer: () => void;
 };
 
 const SKIP_BLOCK_CONFIRM_KEY = "profile_skip_block_confirm";
@@ -292,6 +293,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		selectedActionMessage,
 		selectedActionMessageMine,
 		albumViewer,
+		onCloseAlbumViewer,
 		toggleDrawer,
 		isDrawerOpen,
 		isLoadingDrawer,
@@ -670,7 +672,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                                 {!isDesktop && (
                                     <button
                                         type="button"
-                                        onClick={() => navigate("/chat")}
+                                        onClick={() => { if (albumViewer) { onCloseAlbumViewer(); return; } navigate("/chat"); }}
                                         className="shrink-0 inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface-2)]"
                                         aria-label={t("browse_location.back_aria")}
                                     >

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -1312,6 +1312,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							confirmLabel={t("chat.attachments.send_attachment")}
 							cancelLabel={t("chat.actions.cancel")}
 							isProcessing={isUploadingAttachment}
+							isDesktop={isDesktop}
 						>
 							{attachmentPreviewUrl && (
 								pendingAttachmentFile.type.startsWith("video/") ? (
@@ -1416,6 +1417,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 							}}
 							confirmLabel={t("chat.send")}
 							cancelLabel={t("chat.actions.cancel")}
+							isDesktop={isDesktop}
 						>
 							<div className="px-3 pb-3">
 								<div className="overflow-hidden rounded-xl border border-[var(--border)]" style={{ height: "40dvh" }}>
@@ -1564,7 +1566,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 								role="dialog"
 								aria-modal="true"
 								aria-labelledby="chat-album-share-confirm-title"
-								className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden mx-3"
+								className={`flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden ${isDesktop ? "w-full max-w-[800px] mx-auto" : "mx-3"}`}
 								onClick={(event) => event.stopPropagation()}
 							>
 								<div className="flex items-center justify-between px-4 py-3">
@@ -1904,6 +1906,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					confirmLabel={t("chat.attachments.send_attachment")}
 					cancelLabel={t("chat.actions.cancel")}
 					isProcessing={isUploadingAttachment}
+					isDesktop={true}
 				>
 					{attachmentPreviewUrl && (
 						pendingAttachmentFile.type.startsWith("video/") ? (
@@ -1991,6 +1994,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					}}
 					confirmLabel={t("chat.send")}
 					cancelLabel={t("chat.actions.cancel")}
+					isDesktop={true}
 				>
 					<div className="px-3 pb-3">
 						<div className="overflow-hidden rounded-xl border border-[var(--border)]" style={{ height: "40dvh" }}>
@@ -2015,7 +2019,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
                         role="dialog"
                         aria-modal="true"
                         aria-labelledby="chat-album-share-confirm-title"
-                        className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden mx-3"
+                        className="flex flex-col rounded-t-2xl border-x border-t border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden w-full max-w-[800px] mx-auto"
                         onClick={(event) => event.stopPropagation()}
                     >
                         <div className="flex items-center justify-between px-4 py-3">

--- a/src/pages/app/gridpage/components/LeafletLocationPreview.tsx
+++ b/src/pages/app/gridpage/components/LeafletLocationPreview.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+
+type Props = {
+	lat: number;
+	lon: number;
+	className?: string;
+};
+
+export function LeafletLocationPreview({ lat, lon, className = "h-32 w-full" }: Props) {
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const mapRef = useRef<any>(null);
+
+	useEffect(() => {
+		let mounted = true;
+
+		const init = async () => {
+			try {
+				const L = await import("leaflet");
+				await import("leaflet/dist/leaflet.css");
+				if (!mounted || !containerRef.current || mapRef.current) return;
+
+				const map = L.map(containerRef.current, {
+					zoomControl: false,
+					dragging: false,
+					scrollWheelZoom: false,
+					doubleClickZoom: false,
+					boxZoom: false,
+					keyboard: false,
+					touchZoom: false,
+					attributionControl: false,
+				}).setView([lat, lon], 15);
+
+				L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
+
+				const accentColor = getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#ffcc01";
+				const icon = L.divIcon({
+					className: "",
+					html: `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="${accentColor}" stroke="${accentColor}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12S4 16 4 10a8 8 0 1 1 16 0Z"/><circle cx="12" cy="10" r="3" fill="white" stroke="white"/></svg>`,
+					iconSize: [28, 28],
+					iconAnchor: [14, 28],
+				});
+				L.marker([lat, lon], { icon }).addTo(map);
+
+				mapRef.current = map;
+			} catch {
+				// silently fail
+			}
+		};
+
+		void init();
+
+		return () => {
+			mounted = false;
+			if (mapRef.current) {
+				mapRef.current.remove();
+				mapRef.current = null;
+			}
+		};
+	}, [lat, lon]);
+
+	return <div ref={containerRef} className={className} style={{ isolation: "isolate" }} />;
+}

--- a/src/pages/app/gridpage/components/ProfileDetailsModal.tsx
+++ b/src/pages/app/gridpage/components/ProfileDetailsModal.tsx
@@ -357,11 +357,15 @@ export function ProfileDetailsModal({
 
 			return (
 				<p className="inline-flex items-center gap-1 rounded-full bg-black/65 px-3 py-1 text-xs font-semibold text-white ring-1 ring-white/25">
+                    <style>{`
+                        @keyframes logo-shine { 0%, 100% { filter: drop-shadow(0 0 2px rgba(255,140,0,0.3)) brightness(1); } 50% { filter: drop-shadow(0 0 7px rgba(255,140,0,0.95)) brightness(1.25); } }
+                        .logo-shine { animation: logo-shine 2.8s ease-in-out infinite; }
+                    `}</style>
 					{meta.takenOnGrindr ? (
 						<img
 							src={freegrindLogo}
 							alt={t("chat.thread.taken_on_grindr")}
-							className="h-3.5 w-3.5 rounded-full"
+							className="h-3.5 w-3.5 rounded-full logo-shine"
 						/>
 					) : null}
 					{meta.createdAt ? (

--- a/src/pages/app/profile-editor/ProfileEditorComponents.tsx
+++ b/src/pages/app/profile-editor/ProfileEditorComponents.tsx
@@ -25,38 +25,7 @@ export function CategoryHeader({
 	);
 }
 
-export function ToggleRow({
-	checked,
-	onChange,
-	label,
-	description,
-}: {
-	checked: boolean;
-	onChange: (checked: boolean) => void;
-	label: string;
-	description: string;
-}) {
-	return (
-		<label className="flex min-h-14 items-start justify-between gap-4 rounded-2xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3.5">
-			<span>
-				<span className="block text-sm font-medium">{label}</span>
-				<span className="mt-1 block text-xs leading-relaxed text-[var(--text-muted)]">
-					{description}
-				</span>
-			</span>
-			<span className="relative mt-1 inline-flex h-7 w-12 flex-shrink-0 cursor-pointer items-center">
-				<input
-					type="checkbox"
-					checked={checked}
-					onChange={(event) => onChange(event.target.checked)}
-					className="peer sr-only"
-				/>
-				<span className="absolute inset-0 rounded-full border border-[var(--border)] bg-[var(--surface)] transition-colors peer-checked:border-transparent peer-checked:bg-[var(--accent)]" />
-				<span className="absolute left-1 h-5 w-5 rounded-full bg-[var(--text)] transition-transform peer-checked:translate-x-5 peer-checked:bg-[var(--accent-contrast)]" />
-			</span>
-		</label>
-	);
-}
+export { ToggleRow } from "../../../components/ui/toggle-row";
 
 export function ChipGroup({
 	options,

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -500,6 +500,17 @@ export function createChatService(fetchRest: RestFetcher, t: (key: string) => st
 			await assertSuccess(response, t("chat.errors.album_share_failed"));
 		},
 
+		async stopAlbumShare(albumId: number, recipientProfileId: number) {
+			const response = await fetchRest(
+				`/v1/albums/${albumId}/unshares`,
+				{
+					method: "PUT",
+					body: { profiles: [{ profileId: recipientProfileId, shareId: 0 }] },
+				},
+			);
+			await assertSuccess(response, t("chat.errors.album_share_failed"));
+		},
+
 		async getDrawerMedia(
 			conversationId: string,
 		): Promise<Array<{

--- a/src/services/savedPhrases.ts
+++ b/src/services/savedPhrases.ts
@@ -3,8 +3,6 @@ import { appLog } from "../utils/logger";
 export const SAVED_PHRASES_STORAGE_KEY = "fg-saved-phrases";
 export const SAVED_PHRASES_UPDATED_EVENT = "fg:saved-phrases-updated";
 
-const DEFAULT_SAVED_PHRASES = ["Hey, how are you?", "Looking for?", "I can host!"];
-
 export function normalizeSavedPhrases(input: string[]): string[] {
 	const unique = new Set<string>();
 	for (const phrase of input) {
@@ -18,25 +16,25 @@ export function normalizeSavedPhrases(input: string[]): string[] {
 
 export function loadSavedPhrases(): string[] {
 	if (typeof window === "undefined") {
-		return DEFAULT_SAVED_PHRASES;
+		return [];
 	}
 
 	try {
 		const stored = window.localStorage.getItem(SAVED_PHRASES_STORAGE_KEY);
 		if (!stored) {
-			return DEFAULT_SAVED_PHRASES;
+			return [];
 		}
 		const parsed = JSON.parse(stored);
 		if (!Array.isArray(parsed)) {
-			return DEFAULT_SAVED_PHRASES;
+			return [];
 		}
 		const normalized = normalizeSavedPhrases(
 			parsed.filter((value): value is string => typeof value === "string"),
 		);
-		return normalized.length > 0 ? normalized : DEFAULT_SAVED_PHRASES;
+		return normalized;
 	} catch (error) {
 		appLog.error("[savedPhrases] loadSavedPhrases failed", error);
-		return DEFAULT_SAVED_PHRASES;
+		return [];
 	}
 }
 


### PR DESCRIPTION
This improves the chat UI/UX:
- reorganized chat form
- moved location picker to its own bottom sheet
- sending attachments split
- cropping images and preview
- new audio player
- location message preview
- saved phrases bottom sheet
- simplified adding photos to drawer with separate quick actions
- moved toggle row to its own component and reused on chat drawer upload
- improved safe distance from navigation bar on mobile
- chat input resizes dynamically
- added reusable bottom drawer component
- select new image right after adding it to drawer media
- allow double tap on entire chat bubble 
- close album first when navigating back 
- close bottom sheets first when navigating back 
