### PR TITLE
Fix squished browse grid tiles and crash on older WebKit

### DIFF
--- a/src/components/CrashBoundary.tsx
+++ b/src/components/CrashBoundary.tsx
@@ -1,0 +1,64 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { showCrashOverlay } from "../utils/crashOverlay";
+
+type CrashBoundaryProps = {
+	children: ReactNode;
+};
+
+type CrashBoundaryState = {
+	hasError: boolean;
+	message: string;
+	detail?: string;
+};
+
+/**
+ * Catches React render errors that would otherwise destroy the whole tree
+ * (showing as a black screen) and displays them on screen instead, tbh this is kinda dumb but idk i was bored
+ */
+export class CrashBoundary extends Component<CrashBoundaryProps, CrashBoundaryState> {
+	state: CrashBoundaryState = { hasError: false, message: "" };
+
+	static getDerivedStateFromError(error: Error): CrashBoundaryState {
+		return {
+			hasError: true,
+			message: error.message,
+			detail: error.stack,
+		};
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo) {
+		showCrashOverlay(`React render error: ${error.message}`, `${error.stack}\n\n${info.componentStack}`);
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div
+					style={{
+						position: "fixed",
+						inset: 0,
+						background: "#140000",
+						color: "#fff",
+						fontFamily: "monospace",
+						fontSize: "12px",
+						lineHeight: 1.4,
+						padding: "calc(env(safe-area-inset-top, 0px) + 16px) 12px 16px 12px",
+						overflow: "auto",
+						whiteSpace: "pre-wrap",
+						wordBreak: "break-word",
+						zIndex: 2147483647,
+					}}
+				>
+					<div style={{ fontWeight: "bold", color: "#ff6b6b" }}>
+						React render error: {this.state.message}
+					</div>
+					{this.state.detail && (
+						<div style={{ marginTop: 8, opacity: 0.85 }}>{this.state.detail}</div>
+					)}
+				</div>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,11 @@ import { isTauri } from "@tauri-apps/api/core";
 import { appLog } from "./utils/logger";
 import { CheckCircle2, AlertCircle, Loader2, Info } from "lucide-react";
 import { DEFAULT_GC_TIME_MS } from "./config/ui-constants";
+import { CrashBoundary } from "./components/CrashBoundary";
+import { installGlobalCrashHandlers } from "./utils/crashOverlay";
 import "./index.css";
+
+installGlobalCrashHandlers();
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -38,6 +42,7 @@ if (isTauri()) {
 
 ReactDOM.createRoot(document.getElementById("app")!).render(
 	<React.StrictMode>
+		<CrashBoundary>
 		<QueryClientProvider client={queryClient}>
 			<BrowserRouter>
 				<App />
@@ -75,5 +80,6 @@ ReactDOM.createRoot(document.getElementById("app")!).render(
 				/>
 			</BrowserRouter>
 		</QueryClientProvider>
+		</CrashBoundary>
 	</React.StrictMode>,
 );

--- a/src/pages/app/gridpage/components/BrowseCardTile.tsx
+++ b/src/pages/app/gridpage/components/BrowseCardTile.tsx
@@ -49,7 +49,7 @@ export function BrowseCardTile({
 
 
 	return (
-		<div ref={ref} className={cn(!isDesktop && "bg-black flex rounded-[4px] overflow-hidden", revealClass)}>
+		<div ref={ref} className={cn(!isDesktop && "bg-black rounded-[4px] overflow-hidden", revealClass)}>
 			<button
 				type="button"
 				key={card.profileId}
@@ -74,7 +74,13 @@ export function BrowseCardTile({
 					/>
 				)}
 
-				<div className="relative aspect-[5/5] bg-[var(--surface-2)] z-10 rounded-[inherit] overflow-hidden">
+				{/*
+					Replace "aspect-[5/5]" with "h-0 pb-[100%]", since "aspect-ratio" collapses tile height to ~0 on
+                    pre-iOS-15 WebKit. This triggered an endless pagination loop
+                    that crashed the WebView renderer. thank you flo
+				*/}
+				<div className="relative w-full h-0 pb-[100%] bg-[var(--surface-2)] z-10 rounded-[inherit] overflow-hidden">
+					<div className="absolute inset-0">
 					<ProfileImage
 						src={card.primaryImageUrl}
 						alt={t("browse_page.profile_photo_alt", { name })}
@@ -175,6 +181,7 @@ export function BrowseCardTile({
 							<MapPin className="h-3.5 w-3.5" />
 							{formatDistance(card.distanceMeters, t, unitsPreset)}
 						</span>
+					</div>
 					</div>
 				</div>
 			</button>

--- a/src/pages/app/gridpage/components/BrowseGrid.tsx
+++ b/src/pages/app/gridpage/components/BrowseGrid.tsx
@@ -28,7 +28,7 @@ function BrowseGridSkeleton({ isDesktop, mobileColumns }: { isDesktop: boolean; 
 				<div
 					key={i}
 					className={cn(
-						"animate-pulse bg-[var(--surface-2)] relative aspect-[5/5] overflow-hidden",
+						"animate-pulse bg-[var(--surface-2)] relative w-full h-0 pb-[100%] overflow-hidden",
 						!isDesktop && "rounded-[4px]",
 						isDesktop && "rounded-xl",
 					)}

--- a/src/utils/crashOverlay.ts
+++ b/src/utils/crashOverlay.ts
@@ -1,0 +1,77 @@
+/**
+ * Renders fatal errors directly into the DOM via vanilla JS so they remain visible
+ * even if React itself has crashed and got destroyed (black screen), tho this works 50/50
+ */
+
+let overlayEl: HTMLDivElement | null = null;
+const seenMessages = new Set<string>();
+
+function ensureOverlay(): HTMLDivElement {
+	if (overlayEl) return overlayEl;
+
+	const el = document.createElement("div");
+	el.id = "crash-overlay";
+	el.style.position = "fixed";
+	el.style.inset = "0";
+	el.style.zIndex = "2147483647";
+	el.style.background = "rgba(20, 0, 0, 0.95)";
+	el.style.color = "#fff";
+	el.style.fontFamily = "monospace";
+	el.style.fontSize = "12px";
+	el.style.lineHeight = "1.4";
+	el.style.padding = "calc(env(safe-area-inset-top, 0px) + 16px) 12px 16px 12px";
+	el.style.overflow = "auto";
+	el.style.whiteSpace = "pre-wrap";
+	el.style.wordBreak = "break-word";
+	el.style.pointerEvents = "auto";
+	document.body.appendChild(el);
+	overlayEl = el;
+	return el;
+}
+
+export function showCrashOverlay(title: string, detail?: string) {
+	const key = `${title}\n${detail ?? ""}`;
+	if (seenMessages.has(key)) return;
+	seenMessages.add(key);
+
+	const el = ensureOverlay();
+
+	const block = document.createElement("div");
+	block.style.marginBottom = "12px";
+	block.style.paddingBottom = "12px";
+	block.style.borderBottom = "1px solid rgba(255,255,255,0.2)";
+
+	const titleEl = document.createElement("div");
+	titleEl.style.fontWeight = "bold";
+	titleEl.style.color = "#ff6b6b";
+	titleEl.textContent = title;
+	block.appendChild(titleEl);
+
+	if (detail) {
+		const detailEl = document.createElement("div");
+		detailEl.style.marginTop = "4px";
+		detailEl.style.opacity = "0.85";
+		detailEl.textContent = detail;
+		block.appendChild(detailEl);
+	}
+
+	el.appendChild(block);
+}
+
+export function installGlobalCrashHandlers() {
+	if (typeof window === "undefined") return;
+
+	window.addEventListener("error", (event) => {
+		showCrashOverlay(
+			`Uncaught error: ${event.message}`,
+			event.error?.stack ?? `${event.filename}:${event.lineno}:${event.colno}`,
+		);
+	});
+
+	window.addEventListener("unhandledrejection", (event) => {
+		const reason = event.reason;
+		const message = reason instanceof Error ? reason.message : String(reason);
+		const stack = reason instanceof Error ? reason.stack : undefined;
+		showCrashOverlay(`Unhandled rejection: ${message}`, stack);
+	});
+}


### PR DESCRIPTION
Replace "aspect-[5/5]" with "h-0 pb-[100%]", since "aspect-ratio" collapses tile height to ~0 on pre-iOS-15 WebKit. This triggered an endless pagination loop that crashed the WebView renderer. thank you flo

Also add a global crash overlay and React error boundary