### PR TITLE
Fix chat composer offset and keyboard handling

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/dev/estopia/free_grind/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/dev/estopia/free_grind/MainActivity.kt
@@ -24,7 +24,9 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
@@ -221,6 +223,43 @@ class MainActivity : TauriActivity() {
     }
     dispatchPendingPushNotifications()
     handleNotificationIntent(intent)
+    setupImeInsetsListener(webView)
+  }
+
+  private var lastDispatchedImeInsetPx = -1
+
+  /**
+   * enableEdgeToEdge() (required for this project's targetSdk) means the
+   * system never resizes the window/WebView for the soft keyboard the old
+   * android:windowSoftInputMode="adjustResize" way, so window.innerHeight /
+   * visualViewport never change when it opens — the frontend's own resize
+   * listener has nothing to react to. This reads the real IME inset from the
+   * window insets (the one source that does update as the keyboard
+   * animates) and pushes it into the WebView as a DOM event, in CSS px so it
+   * lines up with the values the frontend already works in.
+   */
+  private fun setupImeInsetsListener(webView: WebView) {
+    ViewCompat.setOnApplyWindowInsetsListener(webView) { _, insets ->
+      val imeHeightPx = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+      if (imeHeightPx != lastDispatchedImeInsetPx) {
+        lastDispatchedImeInsetPx = imeHeightPx
+        val density = resources.displayMetrics.density
+        val imeHeightCss = if (density > 0f) imeHeightPx / density else imeHeightPx.toFloat()
+        dispatchKeyboardInsetToWebview(imeHeightCss)
+      }
+      insets
+    }
+    ViewCompat.requestApplyInsets(webView)
+  }
+
+  private fun dispatchKeyboardInsetToWebview(heightCss: Float) {
+    val script =
+      "(function(){" +
+      "window.dispatchEvent(new CustomEvent('fg:keyboard-inset', { detail: { height: $heightCss } }));" +
+      "})();"
+    runOnUiThread {
+      webViewRef?.evaluateJavascript(script, null)
+    }
   }
 
   override fun onResume() {

--- a/src/pages/app/chat/ChatThreadMessages.tsx
+++ b/src/pages/app/chat/ChatThreadMessages.tsx
@@ -85,6 +85,7 @@ type ChatThreadMessagesProps = {
 	isPartnerTyping?: boolean;
 	isArchived?: boolean;
 	composerHeight?: number;
+	mobileKeyboardInset?: number;
 };
 
 const getReactionEmoji = (type: number): string => {
@@ -293,6 +294,7 @@ export function ChatThreadMessages({
 	isPartnerTyping = false,
 	isArchived = false,
 	composerHeight = 88,
+	mobileKeyboardInset = 0,
 }: ChatThreadMessagesProps) {
 	const { t } = useTranslation();
 	useLocalMediaCache();
@@ -304,6 +306,54 @@ export function ChatThreadMessages({
 	);
 	const [hoveredMediaMessageId, setHoveredMediaMessageId] = useState<string | null>(null);
 	const [contextMenuState, setContextMenuState] = useState<{ messageId: string; x: number; y: number } | null>(null);
+
+	const spacerRef = useRef<HTMLDivElement | null>(null);
+	const previousSpacerHeightRef = useRef<number | null>(null);
+
+	// Resync (without compensating) whenever the open conversation changes —
+	// a different conversation's spacer reflects its own message count, not
+	// a shift of content whose reading position we need to preserve.
+	useLayoutEffect(() => {
+		previousSpacerHeightRef.current = spacerRef.current?.getBoundingClientRect().height ?? null;
+	}, [selectedConversation.data.conversationId]);
+
+	// The bottom-anchoring spacer above resizes whenever anything above the
+	// message list changes size for reasons unrelated to the messages
+	// themselves — composer clearance changing on mobile (keyboard,
+	// quick-phrase pills, draft cleared after send...), a window resize, etc.
+	// When it grows, everything below it — the whole message list — shifts
+	// down by the same amount; scrollTop doesn't move on its own, so a reader
+	// scrolled up into history would otherwise see the view silently jump to
+	// reveal older messages. If they're near the live end instead, snap
+	// fully to the new bottom (this is also what makes the mobile thread
+	// follow the keyboard up). Observes the spacer's actual rendered size
+	// directly rather than guessing at every possible trigger via state
+	// dependencies — ResizeObserver fires after layout but before paint, so
+	// the correction lands before the shifted frame is ever shown.
+	useEffect(() => {
+		const spacer = spacerRef.current;
+		if (!spacer) return;
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			const container = threadScrollContainerRef.current;
+			const newHeight = entry.target.getBoundingClientRect().height;
+			const previous = previousSpacerHeightRef.current;
+			previousSpacerHeightRef.current = newHeight;
+			if (previous === null || !container) return;
+			const shiftDown = newHeight - previous;
+			if (shiftDown === 0) return;
+			const wasNearBottom =
+				container.scrollHeight - container.scrollTop - container.clientHeight < 250;
+			if (wasNearBottom) {
+				container.scrollTop = container.scrollHeight;
+			} else {
+				container.scrollTop = Math.max(0, container.scrollTop + shiftDown);
+			}
+		});
+		observer.observe(spacer);
+		return () => observer.disconnect();
+	}, [threadScrollContainerRef]);
 
 	const reactionButtonRefs = useRef<Map<string, HTMLElement>>(new Map());
 	const prevReactionCountsRef = useRef<Map<string, number>>(new Map());
@@ -767,8 +817,19 @@ export function ChatThreadMessages({
 			onScroll={handleThreadScroll}
 			data-lenis-prevent
 			className={`flex flex-1 flex-col overflow-x-hidden overflow-y-auto ${!isDesktop ? "pt-[140px]" : ""}`}
-			style={!isDesktop ? { paddingBottom: composerHeight + 16 } : undefined}
+			// The +16 is a small safety margin for the last own-message's tiny
+			// READ/UNREAD caption: rapid, back-to-back clearance changes (e.g.
+			// a quick-phrase pill appearing, then sending, then the keyboard
+			// closing) can leave the scroll position a couple of px short of
+			// the true bottom, which is enough to clip a ~14px caption even
+			// though the bubble itself stays fully visible.
+			style={!isDesktop ? { paddingBottom: composerHeight + mobileKeyboardInset + 16 } : undefined}
 		>
+            {/* Grows to push a short thread's messages down against the composer
+                instead of leaving them stranded under the header; shrinks to 0
+                (rather than using justify-end, which WebKit can fail to let you
+                scroll past) once real content overflows the container. */}
+            <div ref={spacerRef} className="flex-1" />
             {messagePageKey ? (
                 <button
                     type="button"

--- a/src/pages/app/chat/ChatThreadPanel.tsx
+++ b/src/pages/app/chat/ChatThreadPanel.tsx
@@ -905,13 +905,24 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 		}
 
 		const viewport = window.visualViewport;
+		// window.innerHeight vs. visualViewport can differ at rest (e.g. a
+		// permanent 3-button nav bar on Android isn't included in one but is
+		// in the other), so an absolute comparison misreads that fixed offset
+		// as "keyboard open" on every load. Track the smallest overlap seen
+		// as the resting baseline and only treat overlap beyond it as the
+		// keyboard actually covering the composer.
+		let restingOverlap: number | null = null;
 
 		const updateKeyboardInset = () => {
 			const layoutHeight = window.innerHeight;
 			const visibleBottom = viewport.height + viewport.offsetTop;
 			const overlap = Math.max(0, Math.round(layoutHeight - visibleBottom));
+			if (restingOverlap === null || overlap < restingOverlap) {
+				restingOverlap = overlap;
+			}
+			const keyboardOverlap = overlap - restingOverlap;
 			// Ignore tiny viewport shifts from browser chrome changes.
-			setMobileKeyboardInset(overlap >= 60 ? overlap : 0);
+			setMobileKeyboardInset(keyboardOverlap >= 60 ? keyboardOverlap : 0);
 		};
 
 		updateKeyboardInset();
@@ -922,6 +933,26 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 			viewport.removeEventListener("resize", updateKeyboardInset);
 			viewport.removeEventListener("scroll", updateKeyboardInset);
 		};
+	}, [isDesktop]);
+
+	// Android's edge-to-edge window (required for this project's targetSdk)
+	// means the OS never resizes the window/WebView for the soft keyboard —
+	// the visualViewport-based effect above simply never sees a change there
+	// (it's kept for iOS/WebKit, which does resize the visual viewport). The
+	// native side (MainActivity.setupImeInsetsListener) reads the real IME
+	// inset from window insets instead and forwards it here as the one
+	// source that reliably tracks the keyboard on Android.
+	useEffect(() => {
+		if (isDesktop) return;
+		const onKeyboardInset = (event: Event) => {
+			const detail = (event as CustomEvent<{ height?: number }>).detail;
+			const height = detail?.height;
+			if (typeof height === "number" && Number.isFinite(height)) {
+				setMobileKeyboardInset(Math.max(0, Math.round(height)));
+			}
+		};
+		window.addEventListener("fg:keyboard-inset", onKeyboardInset);
+		return () => window.removeEventListener("fg:keyboard-inset", onKeyboardInset);
 	}, [isDesktop]);
 
 	// On mobile the thread's header/composer are position:fixed against the
@@ -954,8 +985,17 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 			style={
 				!isDesktop
 					? {
-						height:
-							"calc(100dvh - (env(safe-area-inset-top, 0px) + 16px) - (env(safe-area-inset-bottom, 0px) + 92px))",
+						// No top or bottom term here: the header and composer are
+						// both position:fixed (out of flow), so this wrapper — whose
+						// only in-flow child is the scrollable message list — doesn't
+						// need to carve out room for either. Clearance is already
+						// handled inside the scrollable content itself: pt-[140px]
+						// (header) and paddingBottom = composerHeight +
+						// mobileKeyboardInset (composer), both in ChatThreadMessages.
+						// Subtracting a second, hardcoded estimate here on top of
+						// that left a permanent empty gap at the bottom — the
+						// wrapper simply ended short of the real screen edge.
+						height: "100dvh",
 					}
 					: undefined
 			}
@@ -1576,6 +1616,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 						isPartnerTyping={isPartnerTyping}
 						isArchived={isArchived}
 						composerHeight={composerHeight}
+						mobileKeyboardInset={mobileKeyboardInset}
 				/>
 				)
 			) : (
@@ -1624,7 +1665,7 @@ export function ChatThreadPanel(props: ChatThreadPanelProps) {
 					<form
 						ref={composerRef}
 						onSubmit={onFormSubmit}
-                        className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "relative mt-3 pt-3 -mx-3 sm:-mx-4 px-3 sm:px-4"} border-t border-[var(--border)] bg-[var(--surface)]`}
+						className={`${!isDesktop ? "fixed bottom-0 left-0 right-0 z-30 px-[var(--app-px)] py-3" : "relative mt-3 pt-3 -mx-3 sm:-mx-4 px-3 sm:px-4"} border-t border-[var(--border)] bg-[var(--surface)]`}
 						style={
 							!isDesktop
 								? {


### PR DESCRIPTION
Adds native IME inset tracking (Android edge-to-edge doesn't resize the WebView for the keyboard) and reworks the composer clearance / scroll compensation so the thread stays correctly anchored as the composer height and on-screen keyboard change.