### PR TITLE
Fix iOS crash overlay from Tauri unlisten race

### DIFF
--- a/src/services/tauriWebSocket.ts
+++ b/src/services/tauriWebSocket.ts
@@ -86,7 +86,7 @@ export class TauriWebSocket {
 				// unregister immediately instead of leaking it for the rest of
 				// the app's lifetime. dispatchClose already ran once and won't
 				// run again, so cleanupListener() would never call this.
-				unlisten();
+				this.safeUnlisten(unlisten);
 				return;
 			}
 			this.unlisten = unlisten;
@@ -168,13 +168,25 @@ export class TauriWebSocket {
 	}
 
 	private cleanupListener() {
-		if (this.unlisten) {
-			try {
-				this.unlisten();
-			} catch (error) {
+		const unlisten = this.unlisten;
+		this.unlisten = null;
+		this.safeUnlisten(unlisten);
+	}
+
+	// Tauri v2's unlisten() is async and reads listeners[eventId].handlerId
+	// without a null check. If the webview already dropped that entry
+	// (reload/close race), it rejects as an unhandled promise instead of
+	// throwing synchronously — try/catch around the call is not enough.
+	private safeUnlisten(unlisten: UnlistenFn | null) {
+		if (!unlisten) {
+			return;
+		}
+		try {
+			void Promise.resolve(unlisten()).catch((error) => {
 				appLog.warn("[chat-ws:tauri] unlisten failed", error);
-			}
-			this.unlisten = null;
+			});
+		} catch (error) {
+			appLog.warn("[chat-ws:tauri] unlisten failed", error);
 		}
 	}
 

--- a/src/utils/crashOverlay.ts
+++ b/src/utils/crashOverlay.ts
@@ -6,6 +6,33 @@
 let overlayEl: HTMLDivElement | null = null;
 const seenMessages = new Set<string>();
 
+function errorText(value: unknown): string {
+	if (value == null) {
+		return "";
+	}
+	if (typeof value === "string") {
+		return value;
+	}
+	if (value instanceof Error) {
+		return `${value.message}\n${value.stack ?? ""}`;
+	}
+	// WebKit TypeErrors from Tauri's injected user-script can fail `instanceof Error`.
+	try {
+		const maybe = value as { message?: unknown; stack?: unknown };
+		return `${String(maybe.message ?? value)}\n${String(maybe.stack ?? "")}`;
+	} catch {
+		return String(value);
+	}
+}
+
+function isBenignTauriUnlistenError(text: string): boolean {
+	return (
+		text.includes("listeners[eventId]") ||
+		text.includes("handlerId") ||
+		text.includes("unregisterListener")
+	);
+}
+
 function ensureOverlay(): HTMLDivElement {
 	if (overlayEl) return overlayEl;
 
@@ -24,6 +51,25 @@ function ensureOverlay(): HTMLDivElement {
 	el.style.whiteSpace = "pre-wrap";
 	el.style.wordBreak = "break-word";
 	el.style.pointerEvents = "auto";
+
+	const close = document.createElement("button");
+	close.type = "button";
+	close.textContent = "Dismiss";
+	close.style.display = "block";
+	close.style.margin = "0 0 16px auto";
+	close.style.padding = "8px 12px";
+	close.style.font = "inherit";
+	close.style.color = "#fff";
+	close.style.background = "rgba(255,255,255,0.15)";
+	close.style.border = "1px solid rgba(255,255,255,0.35)";
+	close.style.borderRadius = "8px";
+	close.addEventListener("click", () => {
+		el.remove();
+		overlayEl = null;
+		seenMessages.clear();
+	});
+	el.appendChild(close);
+
 	document.body.appendChild(el);
 	overlayEl = el;
 	return el;
@@ -58,20 +104,82 @@ export function showCrashOverlay(title: string, detail?: string) {
 	el.appendChild(block);
 }
 
+function swallowBenignUnlistenError(error: unknown): boolean {
+	if (isBenignTauriUnlistenError(errorText(error))) {
+		return true;
+	}
+	return false;
+}
+
+function patchTauriEventUnlisten() {
+	const internals = window.__TAURI_EVENT_PLUGIN_INTERNALS__;
+	if (!internals || typeof internals.unregisterListener !== "function") {
+		return false;
+	}
+	const patched = internals as typeof internals & { __fgSafeUnlisten?: boolean };
+	if (patched.__fgSafeUnlisten) {
+		return true;
+	}
+	const original = internals.unregisterListener.bind(internals);
+	internals.unregisterListener = (event: string, eventId: number) => {
+		try {
+			const result = original(event, eventId) as unknown;
+			if (result && typeof (result as Promise<unknown>).then === "function") {
+				return Promise.resolve(result).catch((error) => {
+					if (!swallowBenignUnlistenError(error)) {
+						throw error;
+					}
+				});
+			}
+			return result;
+		} catch (error) {
+			if (!swallowBenignUnlistenError(error)) {
+				throw error;
+			}
+		}
+	};
+	patched.__fgSafeUnlisten = true;
+	return true;
+}
+
 export function installGlobalCrashHandlers() {
 	if (typeof window === "undefined") return;
 
+	if (!patchTauriEventUnlisten()) {
+		let attempts = 0;
+		const timer = window.setInterval(() => {
+			attempts += 1;
+			if (patchTauriEventUnlisten() || attempts > 200) {
+				window.clearInterval(timer);
+			}
+		}, 10);
+	}
+
 	window.addEventListener("error", (event) => {
+		const text = `${event.message ?? ""}\n${errorText(event.error)}`;
+		if (isBenignTauriUnlistenError(text)) {
+			event.preventDefault();
+			return;
+		}
 		showCrashOverlay(
 			`Uncaught error: ${event.message}`,
 			event.error?.stack ?? `${event.filename}:${event.lineno}:${event.colno}`,
 		);
 	});
 
-	window.addEventListener("unhandledrejection", (event) => {
-		const reason = event.reason;
-		const message = reason instanceof Error ? reason.message : String(reason);
-		const stack = reason instanceof Error ? reason.stack : undefined;
-		showCrashOverlay(`Unhandled rejection: ${message}`, stack);
-	});
+	window.addEventListener(
+		"unhandledrejection",
+		(event) => {
+			const reason = event.reason;
+			const text = errorText(reason);
+			if (isBenignTauriUnlistenError(text)) {
+				event.preventDefault();
+				return;
+			}
+			const message = reason instanceof Error ? reason.message : String(reason);
+			const stack = reason instanceof Error ? reason.stack : undefined;
+			showCrashOverlay(`Unhandled rejection: ${message}`, stack);
+		},
+		true,
+	);
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,6 +4,28 @@ import tailwindcss from "@tailwindcss/vite";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+// Tauri v2's unlisten() is async and reads listeners[eventId].handlerId with
+// no null check. A close/reload race becomes an unhandled rejection overlay
+// on iOS WebKit. Wrap the lookup so a missing listener is a no-op.
+function safeTauriUnlisten() {
+	const needle =
+		"window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener(event, eventId);";
+	const replacement =
+		"try { window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener(event, eventId); } catch {}";
+	return {
+		name: "safe-tauri-unlisten",
+		transform(code, id) {
+			if (!id.includes("@tauri-apps/api") || !code.includes(needle)) {
+				return null;
+			}
+			return {
+				code: code.replaceAll(needle, replacement),
+				map: null,
+			};
+		},
+	};
+}
+
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 const packageJsonPath = fileURLToPath(new URL("./package.json", import.meta.url));
@@ -12,7 +34,7 @@ const appVersion = packageJson.version ?? "0.0.0";
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-	plugins: [react(), tailwindcss()],
+	plugins: [safeTauriUnlisten(), react(), tailwindcss()],
 	define: {
 		"import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
 	},


### PR DESCRIPTION
## Summary
- Stops the full-screen red overlay on iOS (`listeners[eventId].handlerId`) when the chat socket unregisters a Tauri event that is already gone.
- Wraps Tauri `unlisten` so a missing listener is a no-op, and ignores that specific unhandled rejection in the crash overlay.
- Adds a Dismiss button if some other overlay still appears.

## Test plan
- [ ] Reproduce chat reconnect / app resume on iOS and confirm the red `unhandled rejection` overlay does not appear
- [ ] Confirm real errors still show in the crash overlay
- [ ] Confirm overlay Dismiss works if a genuine crash is shown


Made with [Cursor](https://cursor.com)